### PR TITLE
feat(core): auto-create .typemd/.gitignore on tmd init

### DIFF
--- a/core/vault.go
+++ b/core/vault.go
@@ -105,6 +105,12 @@ func (v *Vault) Init() error {
 		}
 	}
 
+	// Create .gitignore to exclude index.db
+	gitignore := filepath.Join(v.Dir(), ".gitignore")
+	if err := os.WriteFile(gitignore, []byte("index.db\n"), 0644); err != nil {
+		return fmt.Errorf("create .gitignore: %w", err)
+	}
+
 	// Initialize SQLite DB
 	db, err := sql.Open("sqlite", v.DBPath())
 	if err != nil {

--- a/core/vault_test.go
+++ b/core/vault_test.go
@@ -30,6 +30,24 @@ func TestVault_Init(t *testing.T) {
 	}
 }
 
+func TestVault_Init_Gitignore(t *testing.T) {
+	dir := t.TempDir()
+	v := NewVault(dir)
+
+	if err := v.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	gitignore := filepath.Join(v.Dir(), ".gitignore")
+	data, err := os.ReadFile(gitignore)
+	if err != nil {
+		t.Fatalf("expected .gitignore to exist: %v", err)
+	}
+	if string(data) != "index.db\n" {
+		t.Errorf(".gitignore content = %q, want %q", string(data), "index.db\n")
+	}
+}
+
 func TestVault_Init_AlreadyInitialized(t *testing.T) {
 	dir := t.TempDir()
 	v := NewVault(dir)


### PR DESCRIPTION
## Summary

- `tmd init` now automatically creates `.typemd/.gitignore` with `index.db` entry
- Prevents users from accidentally committing the SQLite database

Closes #1

## Test plan

- [x] Unit test `TestVault_Init_Gitignore` verifies file exists with correct content
- [x] All existing tests pass (`go test ./...`)
- [x] Manual test: `tmd init` in fresh directory creates `.typemd/.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)