### PR TITLE
feat(core): auto-reindex when opening vault with empty index

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ tmd link book/golang-in-action author person/alan-donovan
 # Unlink (with --both to remove inverse side too)
 tmd unlink book/golang-in-action author person/alan-donovan --both
 
-# Sync files to DB and rebuild search index
+# Sync files to DB and rebuild search index (only needed after manual edits)
 tmd reindex
 
 # Validate schemas, objects, and relations

--- a/core/vault.go
+++ b/core/vault.go
@@ -73,7 +73,31 @@ func (v *Vault) Open() error {
 		v.db = nil
 		return fmt.Errorf("ensure schema: %w", err)
 	}
+
+	sync, err := v.needsSync()
+	if err != nil {
+		v.db.Close()
+		v.db = nil
+		return fmt.Errorf("check index: %w", err)
+	}
+	if sync {
+		if err := v.SyncIndex(); err != nil {
+			v.db.Close()
+			v.db = nil
+			return fmt.Errorf("auto sync index: %w", err)
+		}
+	}
+
 	return nil
+}
+
+// needsSync returns true if the objects table has zero rows.
+func (v *Vault) needsSync() (bool, error) {
+	var count int
+	if err := v.db.QueryRow("SELECT COUNT(*) FROM objects").Scan(&count); err != nil {
+		return false, err
+	}
+	return count == 0, nil
 }
 
 // Close closes the SQLite database connection.

--- a/core/vault_test.go
+++ b/core/vault_test.go
@@ -191,6 +191,82 @@ func TestVault_FTSTrigger_InsertSync(t *testing.T) {
 	}
 }
 
+func TestVault_Open_AutoSyncEmptyIndex(t *testing.T) {
+	dir := t.TempDir()
+	v := NewVault(dir)
+	if err := v.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	// Create an object file on disk (simulating a fresh clone)
+	bookDir := filepath.Join(dir, "objects", "book")
+	if err := os.MkdirAll(bookDir, 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := "---\ntitle: Test Book\n---\nHello world\n"
+	if err := os.WriteFile(filepath.Join(bookDir, "test-book.md"), []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// Open should auto-sync because index is empty
+	if err := v.Open(); err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer v.Close()
+
+	var count int
+	if err := v.db.QueryRow("SELECT COUNT(*) FROM objects").Scan(&count); err != nil {
+		t.Fatalf("count query error = %v", err)
+	}
+	if count != 1 {
+		t.Errorf("objects count = %d, want 1", count)
+	}
+}
+
+func TestVault_Open_SkipSyncWhenIndexPopulated(t *testing.T) {
+	dir := t.TempDir()
+	v := NewVault(dir)
+	if err := v.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+
+	// Open and manually insert an object
+	if err := v.Open(); err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	_, err := v.db.Exec(`INSERT INTO objects (id, type, filename, properties, body) VALUES ('book/existing', 'book', 'existing', '{}', '')`)
+	if err != nil {
+		t.Fatalf("insert error = %v", err)
+	}
+	v.Close()
+
+	// Create a second object on disk that would be picked up by SyncIndex
+	bookDir := filepath.Join(dir, "objects", "book")
+	if err := os.MkdirAll(bookDir, 0755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := "---\ntitle: New Book\n---\nBody\n"
+	if err := os.WriteFile(filepath.Join(bookDir, "new-book.md"), []byte(content), 0644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// Re-open: index already has data, so auto-sync should NOT run
+	v2 := NewVault(dir)
+	if err := v2.Open(); err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer v2.Close()
+
+	var count int
+	if err := v2.db.QueryRow("SELECT COUNT(*) FROM objects").Scan(&count); err != nil {
+		t.Fatalf("count query error = %v", err)
+	}
+	// Should still be 1 (the manually inserted one), NOT 2
+	if count != 1 {
+		t.Errorf("objects count = %d, want 1 (auto-sync should not have run)", count)
+	}
+}
+
 // setupTestVault creates a temporary vault with Init + Open, auto-cleanup on test end.
 func setupTestVault(t *testing.T) *Vault {
 	t.Helper()

--- a/docs/src/content/docs/architecture/data-model.md
+++ b/docs/src/content/docs/architecture/data-model.md
@@ -30,7 +30,7 @@ TypeMD uses SQLite with FTS5 for indexing. The index is stored at `.typemd/index
 - Object metadata (type, filename, properties)
 - Full-text search index over filenames, properties, and body content
 
-The index is automatically updated when using the TUI or CLI commands. Use `tmd reindex` to rebuild after manual file edits.
+The index is automatically synced when opening a vault with an empty or missing database (e.g. after a fresh clone). It is also kept up-to-date when using the TUI or CLI commands. Use `tmd reindex` to rebuild after manual file edits outside of TypeMD.
 
 ## Architecture
 

--- a/docs/src/content/docs/getting-started/quick-start.md
+++ b/docs/src/content/docs/getting-started/quick-start.md
@@ -37,7 +37,7 @@ rating: 4.5
 A great book about Go...
 ```
 
-The TUI will automatically detect the new file and display it.
+The TUI will automatically detect the new file and display it. If you cloned an existing vault, the database is populated automatically on first open — no manual `tmd reindex` needed.
 
 ## 4. Query and Search
 

--- a/docs/src/content/docs/reference/reindex.md
+++ b/docs/src/content/docs/reference/reindex.md
@@ -5,7 +5,9 @@ sidebar:
   order: 8
 ---
 
-Scans the `objects/` directory, syncs all files to the database, and rebuilds the full-text search index. Use after manually editing files.
+Scans the `objects/` directory, syncs all files to the database, and rebuilds the full-text search index. Use after manually editing files outside of TypeMD.
+
+> **Note:** When opening a vault, TypeMD automatically syncs the index if it is empty or missing. You only need `tmd reindex` when files have been edited while the vault was not open.
 
 ```bash
 tmd reindex


### PR DESCRIPTION
## Summary

- When opening a vault, if the SQLite `objects` table has zero rows, automatically call `SyncIndex()` to populate the index from disk
- This ensures fresh clones work without requiring manual `tmd reindex`

## Issue

Closes #41

## Changes

- **core/vault.go**: Added `needsSync()` method and modified `Open()` to auto-sync when index is empty
- **core/vault_test.go**: Added tests for auto-sync and skip-sync scenarios
- **Documentation**: Updated README and docs to reflect auto-sync behavior

## Test Plan

- ✅ All tests pass (`go test ./...`)
- ✅ `TestVault_Open_AutoSyncEmptyIndex` verifies auto-sync on empty index
- ✅ `TestVault_Open_SkipSyncWhenIndexPopulated` verifies no double-sync when index already has data

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)