### PR TITLE
feat(cli): add create command for objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ tmd
 # Open TUI with specific vault path
 tmd --vault /path/to/vault
 
+# Create a new object
+tmd create book clean-code
+
 # Show object detail
 tmd show book/golang-in-action
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/typemd/typemd/core"
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create <type> <name>",
+	Short: "Create a new object from a type schema",
+	Long: `Create a new object file (Markdown + YAML frontmatter) based on the type schema.
+
+Examples:
+  tmd create book clean-code
+  tmd create person robert-martin`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vault := core.NewVault(vaultPath)
+		if vaultPath == "" {
+			vault = core.NewVault(".")
+		}
+		if err := vault.Open(); err != nil {
+			return err
+		}
+		defer vault.Close()
+
+		obj, err := vault.NewObject(args[0], args[1])
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Created %s\n", obj.ID)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(createCmd)
+}

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/typemd/typemd/core"
+)
+
+func setupTestVaultDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	v := core.NewVault(dir)
+	if err := v.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := v.Open(); err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	v.Close()
+	return dir
+}
+
+func TestCreateCmd_Success(t *testing.T) {
+	dir := setupTestVaultDir(t)
+
+	vaultPath = dir
+	rootCmd.SetArgs([]string{"create", "book", "clean-code"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	// Verify file was created
+	objPath := filepath.Join(dir, "objects", "book", "clean-code.md")
+	if _, err := os.Stat(objPath); os.IsNotExist(err) {
+		t.Error("expected object file to exist")
+	}
+}
+
+func TestCreateCmd_UnknownType(t *testing.T) {
+	dir := setupTestVaultDir(t)
+
+	vaultPath = dir
+	rootCmd.SetArgs([]string{"create", "nonexistent", "foo"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+}
+
+func TestCreateCmd_Duplicate(t *testing.T) {
+	dir := setupTestVaultDir(t)
+
+	vaultPath = dir
+
+	// Create first
+	rootCmd.SetArgs([]string{"create", "book", "duplicate"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("first create error = %v", err)
+	}
+
+	// Create duplicate
+	rootCmd.SetArgs([]string{"create", "book", "duplicate"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for duplicate object")
+	}
+}

--- a/docs/src/content/docs/reference/create.md
+++ b/docs/src/content/docs/reference/create.md
@@ -1,0 +1,17 @@
+---
+title: tmd create
+description: Create a new object from a type schema.
+sidebar:
+  order: 2.5
+---
+
+Creates a new object file (Markdown + YAML frontmatter) based on the type schema.
+
+```bash
+tmd create book clean-code
+tmd create person robert-martin
+```
+
+The command generates a `.md` file under `objects/<type>/` with all schema-defined properties set to their default values (or `null` if no default is specified). The object is also added to the SQLite index.
+
+If the type does not exist or an object with the same name already exists, an error is returned.


### PR DESCRIPTION
## Summary

- Adds `tmd create <type> <name>` CLI command
- Generates object files with YAML frontmatter from type schemas
- Updates documentation (README + reference docs)

## Issue

Closes #18

## Test Plan

- Run `go test ./cmd/` — 3 new tests pass (success, unknown type, duplicate)
- Run `go test ./...` — all existing tests still pass
- Manual test: `tmd create book test-book` creates correct file structure

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)