### PR TITLE
feat(core): detect and clean up orphaned relations during SyncIndex

### DIFF
--- a/cmd/reindex.go
+++ b/cmd/reindex.go
@@ -10,7 +10,7 @@ import (
 var reindexCmd = &cobra.Command{
 	Use:   "reindex",
 	Short: "Sync objects from disk and rebuild search index",
-	Long:  `Scan the objects directory, sync all files to the database, and rebuild the FTS5 search index.`,
+	Long:  `Scan the objects directory, sync all files to the database, clean up orphaned relations, and rebuild the FTS5 search index.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vault := core.NewVault(vaultPath)
 		if vaultPath == "" {
@@ -21,11 +21,19 @@ var reindexCmd = &cobra.Command{
 		}
 		defer vault.Close()
 
-		if err := vault.SyncIndex(); err != nil {
+		result, err := vault.SyncIndex()
+		if err != nil {
 			return err
 		}
 
 		fmt.Println("Index synced successfully.")
+		if len(result.Orphaned) > 0 {
+			fmt.Printf("Warning: Found %d orphaned relation(s):\n", len(result.Orphaned))
+			for _, o := range result.Orphaned {
+				fmt.Printf("  %s -> %s (relation: %q)\n", o.FromID, o.ToID, o.Name)
+			}
+			fmt.Println("Orphaned relations have been removed from the index.")
+		}
 		return nil
 	},
 }

--- a/core/sync.go
+++ b/core/sync.go
@@ -8,12 +8,29 @@ import (
 	"strings"
 )
 
+// OrphanedRelation represents a relation record that references a non-existent object.
+type OrphanedRelation struct {
+	Name   string
+	FromID string
+	ToID   string
+}
+
+// SyncResult holds statistics from a SyncIndex operation.
+type SyncResult struct {
+	Created  int
+	Updated  int
+	Deleted  int
+	Orphaned []OrphanedRelation
+}
+
 // SyncIndex scans the objects directory, upserts all found objects into the DB,
-// removes DB entries for deleted files, and rebuilds the FTS index.
-func (v *Vault) SyncIndex() error {
+// removes DB entries for deleted files, cleans up orphaned relations, and rebuilds the FTS index.
+func (v *Vault) SyncIndex() (*SyncResult, error) {
 	if v.db == nil {
-		return fmt.Errorf("vault not opened")
+		return nil, fmt.Errorf("vault not opened")
 	}
+
+	result := &SyncResult{}
 
 	// Collect all object IDs found on disk
 	diskIDs := make(map[string]bool)
@@ -23,9 +40,9 @@ func (v *Vault) SyncIndex() error {
 		// No objects directory — just clean DB and return
 		_, err := v.db.Exec("DELETE FROM objects")
 		if err != nil {
-			return fmt.Errorf("clean objects: %w", err)
+			return nil, fmt.Errorf("clean objects: %w", err)
 		}
-		return v.RebuildIndex()
+		return result, v.RebuildIndex()
 	}
 
 	// Walk objects/<type>/<name>.md
@@ -81,13 +98,13 @@ func (v *Vault) SyncIndex() error {
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("walk objects: %w", err)
+		return nil, fmt.Errorf("walk objects: %w", err)
 	}
 
 	// Remove DB entries that no longer exist on disk
 	rows, err := v.db.Query("SELECT id FROM objects")
 	if err != nil {
-		return fmt.Errorf("list db objects: %w", err)
+		return nil, fmt.Errorf("list db objects: %w", err)
 	}
 	defer rows.Close()
 
@@ -95,21 +112,60 @@ func (v *Vault) SyncIndex() error {
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
-			return fmt.Errorf("scan id: %w", err)
+			return nil, fmt.Errorf("scan id: %w", err)
 		}
 		if !diskIDs[id] {
 			toDelete = append(toDelete, id)
 		}
 	}
 	if err := rows.Err(); err != nil {
-		return fmt.Errorf("iterate db objects: %w", err)
+		return nil, fmt.Errorf("iterate db objects: %w", err)
 	}
 
 	for _, id := range toDelete {
 		if _, err := v.db.Exec("DELETE FROM objects WHERE id = ?", id); err != nil {
-			return fmt.Errorf("delete stale object %s: %w", id, err)
+			return nil, fmt.Errorf("delete stale object %s: %w", id, err)
+		}
+	}
+	result.Deleted = len(toDelete)
+
+	// Detect and clean up orphaned relations
+	orphanRows, err := v.db.Query(`
+		SELECT r.name, r.from_id, r.to_id FROM relations r
+		LEFT JOIN objects o1 ON r.from_id = o1.id
+		LEFT JOIN objects o2 ON r.to_id = o2.id
+		WHERE o1.id IS NULL OR o2.id IS NULL
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("detect orphaned relations: %w", err)
+	}
+	defer orphanRows.Close()
+
+	for orphanRows.Next() {
+		var o OrphanedRelation
+		if err := orphanRows.Scan(&o.Name, &o.FromID, &o.ToID); err != nil {
+			return nil, fmt.Errorf("scan orphaned relation: %w", err)
+		}
+		result.Orphaned = append(result.Orphaned, o)
+	}
+	if err := orphanRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate orphaned relations: %w", err)
+	}
+
+	// Delete orphaned relations from DB
+	if len(result.Orphaned) > 0 {
+		_, err := v.db.Exec(`
+			DELETE FROM relations WHERE id IN (
+				SELECT r.id FROM relations r
+				LEFT JOIN objects o1 ON r.from_id = o1.id
+				LEFT JOIN objects o2 ON r.to_id = o2.id
+				WHERE o1.id IS NULL OR o2.id IS NULL
+			)
+		`)
+		if err != nil {
+			return nil, fmt.Errorf("delete orphaned relations: %w", err)
 		}
 	}
 
-	return v.RebuildIndex()
+	return result, v.RebuildIndex()
 }

--- a/core/sync_test.go
+++ b/core/sync_test.go
@@ -18,7 +18,7 @@ func TestVault_SyncIndex_NewFile(t *testing.T) {
 	// Also need type schema for the type directory to be valid
 	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"), []byte("name: book\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
-	if err := v.SyncIndex(); err != nil {
+	if _, err := v.SyncIndex(); err != nil {
 		t.Fatalf("SyncIndex() error = %v", err)
 	}
 
@@ -47,7 +47,7 @@ func TestVault_SyncIndex_UpdatedFile(t *testing.T) {
 	objPath := v.ObjectPath("book", "test-book")
 	os.WriteFile(objPath, []byte("---\ntitle: Updated\n---\n\nNew body content.\n"), 0644)
 
-	if err := v.SyncIndex(); err != nil {
+	if _, err := v.SyncIndex(); err != nil {
 		t.Fatalf("SyncIndex() error = %v", err)
 	}
 
@@ -74,8 +74,12 @@ func TestVault_SyncIndex_DeletedFile(t *testing.T) {
 	// Delete the file
 	os.Remove(v.ObjectPath("book", "test-book"))
 
-	if err := v.SyncIndex(); err != nil {
+	result, err := v.SyncIndex()
+	if err != nil {
 		t.Fatalf("SyncIndex() error = %v", err)
+	}
+	if result.Deleted != 1 {
+		t.Errorf("Deleted = %d, want 1", result.Deleted)
 	}
 
 	objs, err := v.QueryObjects("type=book")
@@ -92,8 +96,105 @@ func TestVault_SyncIndex_DBNotOpen(t *testing.T) {
 	v := NewVault(dir)
 	v.Init()
 
-	err := v.SyncIndex()
+	_, err := v.SyncIndex()
 	if err == nil {
 		t.Fatal("expected error when DB not opened, got nil")
+	}
+}
+
+func TestVault_SyncIndex_OrphanedRelations(t *testing.T) {
+	v := setupRelationTestVault(t)
+
+	// Create two objects and link them
+	v.NewObject("book", "golang-in-action")
+	v.NewObject("person", "alan-donovan")
+	v.LinkObjects("book/golang-in-action", "author", "person/alan-donovan")
+
+	// Verify relations exist
+	var count int
+	v.db.QueryRow("SELECT COUNT(*) FROM relations").Scan(&count)
+	if count == 0 {
+		t.Fatal("expected relations to exist before deletion")
+	}
+
+	// Delete the person file from disk (simulating user deletion)
+	os.Remove(v.ObjectPath("person", "alan-donovan"))
+
+	// SyncIndex should detect and clean orphaned relations
+	result, err := v.SyncIndex()
+	if err != nil {
+		t.Fatalf("SyncIndex() error = %v", err)
+	}
+
+	if len(result.Orphaned) == 0 {
+		t.Fatal("expected orphaned relations, got none")
+	}
+
+	// Verify orphaned relations contain the right data
+	found := false
+	for _, o := range result.Orphaned {
+		if o.ToID == "person/alan-donovan" || o.FromID == "person/alan-donovan" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected orphan referencing person/alan-donovan, got %+v", result.Orphaned)
+	}
+
+	// Verify relations table is now clean
+	v.db.QueryRow("SELECT COUNT(*) FROM relations").Scan(&count)
+	if count != 0 {
+		t.Errorf("relations count after cleanup = %d, want 0", count)
+	}
+}
+
+func TestVault_SyncIndex_NoOrphansWhenAllExist(t *testing.T) {
+	v := setupRelationTestVault(t)
+
+	v.NewObject("book", "test-book")
+	v.NewObject("person", "alan")
+	v.LinkObjects("book/test-book", "author", "person/alan")
+
+	result, err := v.SyncIndex()
+	if err != nil {
+		t.Fatalf("SyncIndex() error = %v", err)
+	}
+
+	if len(result.Orphaned) != 0 {
+		t.Errorf("expected no orphans, got %+v", result.Orphaned)
+	}
+
+	// Relations should still exist
+	var count int
+	v.db.QueryRow("SELECT COUNT(*) FROM relations").Scan(&count)
+	if count == 0 {
+		t.Error("expected relations to still exist")
+	}
+}
+
+func TestVault_SyncIndex_OrphanFromSourceDeletion(t *testing.T) {
+	v := setupRelationTestVault(t)
+
+	v.NewObject("book", "test-book")
+	v.NewObject("person", "alan")
+	v.LinkObjects("book/test-book", "author", "person/alan")
+
+	// Delete the source (book) instead of the target
+	os.Remove(v.ObjectPath("book", "test-book"))
+
+	result, err := v.SyncIndex()
+	if err != nil {
+		t.Fatalf("SyncIndex() error = %v", err)
+	}
+
+	if len(result.Orphaned) == 0 {
+		t.Fatal("expected orphaned relations when source is deleted")
+	}
+
+	// Verify relations table is clean
+	var count int
+	v.db.QueryRow("SELECT COUNT(*) FROM relations").Scan(&count)
+	if count != 0 {
+		t.Errorf("relations count after cleanup = %d, want 0", count)
 	}
 }

--- a/core/vault.go
+++ b/core/vault.go
@@ -81,7 +81,7 @@ func (v *Vault) Open() error {
 		return fmt.Errorf("check index: %w", err)
 	}
 	if sync {
-		if err := v.SyncIndex(); err != nil {
+		if _, err := v.SyncIndex(); err != nil {
 			v.db.Close()
 			v.db = nil
 			return fmt.Errorf("auto sync index: %w", err)

--- a/docs/src/content/docs/reference/reindex.md
+++ b/docs/src/content/docs/reference/reindex.md
@@ -5,10 +5,23 @@ sidebar:
   order: 8
 ---
 
-Scans the `objects/` directory, syncs all files to the database, and rebuilds the full-text search index. Use after manually editing files outside of TypeMD.
+Scans the `objects/` directory, syncs all files to the database, cleans up orphaned relations, and rebuilds the full-text search index. Use after manually editing files outside of TypeMD.
 
 > **Note:** When opening a vault, TypeMD automatically syncs the index if it is empty or missing. You only need `tmd reindex` when files have been edited while the vault was not open.
 
 ```bash
 tmd reindex
 ```
+
+## Orphaned relation cleanup
+
+When an object is deleted from disk, any relations pointing to or from that object become orphaned. During reindex, these dangling references are automatically detected and removed from the index. A warning is displayed listing the affected relations:
+
+```
+Warning: Found 2 orphaned relation(s):
+  book/golang-in-action -> person/deleted-author (relation: "author")
+  person/deleted-author -> book/golang-in-action (relation: "books")
+Orphaned relations have been removed from the index.
+```
+
+> **Note:** This only cleans up the SQLite index. The frontmatter in `.md` files is not modified — use `tmd unlink --both` to properly remove relations before deleting objects.

--- a/docs/src/content/docs/zh-tw/reference/reindex.md
+++ b/docs/src/content/docs/zh-tw/reference/reindex.md
@@ -5,10 +5,23 @@ sidebar:
   order: 8
 ---
 
-掃描 `objects/` 目錄，將所有檔案同步到資料庫，並重建全文搜尋索引。在 TypeMD 外部手動編輯檔案後使用。
+掃描 `objects/` 目錄，將所有檔案同步到資料庫，清理孤立的 relation，並重建全文搜尋索引。在 TypeMD 外部手動編輯檔案後使用。
 
 > **注意：** 開啟 vault 時，TypeMD 會在索引為空或缺失時自動同步。只有在 vault 未開啟期間編輯了檔案，才需要執行 `tmd reindex`。
 
 ```bash
 tmd reindex
 ```
+
+## 孤立 relation 清理
+
+當物件從磁碟中刪除時，指向或來自該物件的 relation 會變成孤立的。在 reindex 過程中，這些 dangling reference 會自動被偵測並從索引中移除。系統會顯示受影響的 relation 列表：
+
+```
+Warning: Found 2 orphaned relation(s):
+  book/golang-in-action -> person/deleted-author (relation: "author")
+  person/deleted-author -> book/golang-in-action (relation: "books")
+Orphaned relations have been removed from the index.
+```
+
+> **注意：** 這只會清理 SQLite 索引。`.md` 檔案中的 frontmatter 不會被修改 — 建議在刪除物件前先使用 `tmd unlink --both` 正確移除 relation。


### PR DESCRIPTION
## Summary

- `SyncIndex()` now returns `(*SyncResult, error)` with orphan detection stats
- After deleting stale objects, orphaned relations (referencing non-existent objects) are detected via SQL and automatically removed from the relations table
- `tmd reindex` displays warnings listing affected orphaned relations
- Documentation updated (EN/zh-TW) for the reindex command

## Issue

Closes #21

## Test Plan

- [x] `TestVault_SyncIndex_OrphanedRelations` — delete target object, verify orphans detected and cleaned
- [x] `TestVault_SyncIndex_NoOrphansWhenAllExist` — no false positives
- [x] `TestVault_SyncIndex_OrphanFromSourceDeletion` — delete source object, verify orphans detected
- [x] All existing tests pass with updated `SyncIndex()` signature
- [x] `go vet ./...` clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)