### PR TITLE
feat(cli): add tmd migrate command for type schema migration

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/typemd/typemd/core"
+)
+
+var migrateDryRun bool
+var migrateRenames []string
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate <type>",
+	Short: "Update objects to match the current type schema",
+	Long: `Migrate all objects of a given type to match the current schema.
+Adds missing properties (with defaults), removes obsolete ones,
+and optionally renames properties.
+
+Examples:
+  tmd migrate book
+  tmd migrate book --dry-run
+  tmd migrate book --rename old_field:new_field`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vault := core.NewVault(vaultPath)
+		if vaultPath == "" {
+			vault = core.NewVault(".")
+		}
+		if err := vault.Open(); err != nil {
+			return err
+		}
+		defer vault.Close()
+
+		opts := core.MigrateOptions{
+			DryRun:  migrateDryRun,
+			Renames: make(map[string]string),
+		}
+
+		for _, r := range migrateRenames {
+			pair := strings.SplitN(r, ":", 2)
+			if len(pair) != 2 || pair[0] == "" || pair[1] == "" {
+				return fmt.Errorf("invalid rename format %q, expected old_name:new_name", r)
+			}
+			opts.Renames[pair[0]] = pair[1]
+		}
+
+		result, err := vault.MigrateObjects(args[0], opts)
+		if err != nil {
+			return err
+		}
+
+		if len(result.Changes) == 0 {
+			fmt.Println("All objects already match the schema. No changes needed.")
+			return nil
+		}
+
+		if migrateDryRun {
+			fmt.Println("Dry run — no files modified:")
+		}
+
+		for _, c := range result.Changes {
+			var summary []string
+			if len(c.Added) > 0 {
+				summary = append(summary, fmt.Sprintf("added %v", c.Added))
+			}
+			if len(c.Removed) > 0 {
+				summary = append(summary, fmt.Sprintf("removed %v", c.Removed))
+			}
+			for old, new := range c.Renamed {
+				summary = append(summary, fmt.Sprintf("renamed %s -> %s", old, new))
+			}
+			fmt.Printf("  %s: %s\n", c.ObjectID, strings.Join(summary, ", "))
+		}
+
+		fmt.Printf("Migration complete: %d object(s) updated.\n", len(result.Changes))
+		return nil
+	},
+}
+
+func init() {
+	migrateCmd.Flags().BoolVar(&migrateDryRun, "dry-run", false, "Preview changes without modifying files")
+	migrateCmd.Flags().StringArrayVar(&migrateRenames, "rename", nil, "Rename a property (format: old_name:new_name, repeatable)")
+	rootCmd.AddCommand(migrateCmd)
+}

--- a/core/migrate.go
+++ b/core/migrate.go
@@ -1,0 +1,111 @@
+package core
+
+import "fmt"
+
+// MigrateOptions configures a migration operation.
+type MigrateOptions struct {
+	DryRun  bool
+	Renames map[string]string // old_name -> new_name
+}
+
+// MigrateChange describes the changes applied to a single object.
+type MigrateChange struct {
+	ObjectID string
+	Added    []string
+	Removed  []string
+	Renamed  map[string]string // old -> new
+}
+
+// MigrateResult holds the outcome of a migration operation.
+type MigrateResult struct {
+	Changes []MigrateChange
+}
+
+// MigrateObjects updates all objects of the given type to match the current schema.
+// It adds missing properties (with defaults), removes obsolete ones, and optionally
+// renames properties specified in opts.Renames.
+func (v *Vault) MigrateObjects(typeName string, opts MigrateOptions) (*MigrateResult, error) {
+	if v.db == nil {
+		return nil, fmt.Errorf("vault not opened")
+	}
+
+	schema, err := v.LoadType(typeName)
+	if err != nil {
+		return nil, fmt.Errorf("load type %q: %w", typeName, err)
+	}
+
+	// Build set of schema property names
+	schemaProps := make(map[string]Property)
+	for _, p := range schema.Properties {
+		schemaProps[p.Name] = p
+	}
+
+	// Validate rename mappings
+	for oldName, newName := range opts.Renames {
+		if _, exists := schemaProps[newName]; !exists {
+			return nil, fmt.Errorf("rename target %q not found in schema %q", newName, typeName)
+		}
+		if _, exists := schemaProps[oldName]; exists {
+			return nil, fmt.Errorf("rename source %q still exists in schema %q (remove it from schema first)", oldName, typeName)
+		}
+	}
+
+	// Query all objects of this type
+	objects, err := v.QueryObjects("type=" + typeName)
+	if err != nil {
+		return nil, fmt.Errorf("query objects: %w", err)
+	}
+
+	result := &MigrateResult{}
+
+	for _, obj := range objects {
+		change := MigrateChange{ObjectID: obj.ID}
+
+		// 1. Rename: move old property value to new name
+		for oldName, newName := range opts.Renames {
+			oldVal, hasOld := obj.Properties[oldName]
+			_, hasNew := obj.Properties[newName]
+			if hasOld && !hasNew {
+				obj.Properties[newName] = oldVal
+				delete(obj.Properties, oldName)
+				if change.Renamed == nil {
+					change.Renamed = make(map[string]string)
+				}
+				change.Renamed[oldName] = newName
+			}
+		}
+
+		// 2. Add: schema properties missing from object
+		for _, p := range schema.Properties {
+			if _, exists := obj.Properties[p.Name]; !exists {
+				obj.Properties[p.Name] = p.Default
+				change.Added = append(change.Added, p.Name)
+			}
+		}
+
+		// 3. Remove: object properties not in schema (and not a rename source)
+		for key := range obj.Properties {
+			if _, inSchema := schemaProps[key]; !inSchema {
+				if _, isRenameSource := opts.Renames[key]; !isRenameSource {
+					delete(obj.Properties, key)
+					change.Removed = append(change.Removed, key)
+				}
+			}
+		}
+
+		// Skip if no changes
+		if len(change.Added) == 0 && len(change.Removed) == 0 && len(change.Renamed) == 0 {
+			continue
+		}
+
+		if !opts.DryRun {
+			if err := v.writeObjectProperties(obj); err != nil {
+				return nil, fmt.Errorf("write object %s: %w", obj.ID, err)
+			}
+		}
+
+		result.Changes = append(result.Changes, change)
+	}
+
+	return result, nil
+}

--- a/core/migrate_test.go
+++ b/core/migrate_test.go
@@ -1,0 +1,227 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupMigrateTestVault(t *testing.T) *Vault {
+	t.Helper()
+	v := setupTestVault(t)
+
+	// Initial schema with title and status
+	schema := []byte(`name: book
+properties:
+  - name: title
+    type: string
+  - name: status
+    type: string
+`)
+	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"), schema, 0644)
+	return v
+}
+
+func TestVault_MigrateObjects_AddProperty(t *testing.T) {
+	v := setupMigrateTestVault(t)
+
+	// Create objects with original schema
+	v.NewObject("book", "book-a")
+	v.NewObject("book", "book-b")
+
+	// Update schema: add isbn with default
+	newSchema := []byte(`name: book
+properties:
+  - name: title
+    type: string
+  - name: status
+    type: string
+  - name: isbn
+    type: string
+    default: "unknown"
+`)
+	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"), newSchema, 0644)
+
+	result, err := v.MigrateObjects("book", MigrateOptions{})
+	if err != nil {
+		t.Fatalf("MigrateObjects() error = %v", err)
+	}
+
+	if len(result.Changes) != 2 {
+		t.Fatalf("len(Changes) = %d, want 2", len(result.Changes))
+	}
+
+	// Verify both objects now have isbn
+	for _, name := range []string{"book-a", "book-b"} {
+		obj, err := v.GetObject("book/" + name)
+		if err != nil {
+			t.Fatalf("GetObject(%s) error = %v", name, err)
+		}
+		if obj.Properties["isbn"] != "unknown" {
+			t.Errorf("%s isbn = %v, want %q", name, obj.Properties["isbn"], "unknown")
+		}
+	}
+}
+
+func TestVault_MigrateObjects_RemoveProperty(t *testing.T) {
+	v := setupMigrateTestVault(t)
+
+	v.NewObject("book", "test")
+
+	// Update schema: remove status
+	newSchema := []byte(`name: book
+properties:
+  - name: title
+    type: string
+`)
+	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"), newSchema, 0644)
+
+	result, err := v.MigrateObjects("book", MigrateOptions{})
+	if err != nil {
+		t.Fatalf("MigrateObjects() error = %v", err)
+	}
+
+	if len(result.Changes) != 1 {
+		t.Fatalf("len(Changes) = %d, want 1", len(result.Changes))
+	}
+	if len(result.Changes[0].Removed) != 1 || result.Changes[0].Removed[0] != "status" {
+		t.Errorf("Removed = %v, want [status]", result.Changes[0].Removed)
+	}
+
+	obj, _ := v.GetObject("book/test")
+	if _, exists := obj.Properties["status"]; exists {
+		t.Error("status property should have been removed")
+	}
+}
+
+func TestVault_MigrateObjects_RenameProperty(t *testing.T) {
+	v := setupMigrateTestVault(t)
+
+	obj, _ := v.NewObject("book", "test")
+	v.SetProperty(obj.ID, "status", "reading")
+
+	// Update schema: rename status -> reading_status
+	newSchema := []byte(`name: book
+properties:
+  - name: title
+    type: string
+  - name: reading_status
+    type: string
+`)
+	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"), newSchema, 0644)
+
+	result, err := v.MigrateObjects("book", MigrateOptions{
+		Renames: map[string]string{"status": "reading_status"},
+	})
+	if err != nil {
+		t.Fatalf("MigrateObjects() error = %v", err)
+	}
+
+	if len(result.Changes) != 1 {
+		t.Fatalf("len(Changes) = %d, want 1", len(result.Changes))
+	}
+	if result.Changes[0].Renamed["status"] != "reading_status" {
+		t.Errorf("Renamed = %v, want status->reading_status", result.Changes[0].Renamed)
+	}
+
+	updated, _ := v.GetObject("book/test")
+	if updated.Properties["reading_status"] != "reading" {
+		t.Errorf("reading_status = %v, want %q", updated.Properties["reading_status"], "reading")
+	}
+	if _, exists := updated.Properties["status"]; exists {
+		t.Error("old property 'status' should have been removed")
+	}
+}
+
+func TestVault_MigrateObjects_DryRun(t *testing.T) {
+	v := setupMigrateTestVault(t)
+
+	v.NewObject("book", "test")
+
+	// Update schema: add isbn
+	newSchema := []byte(`name: book
+properties:
+  - name: title
+    type: string
+  - name: status
+    type: string
+  - name: isbn
+    type: string
+    default: "unknown"
+`)
+	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"), newSchema, 0644)
+
+	result, err := v.MigrateObjects("book", MigrateOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("MigrateObjects() error = %v", err)
+	}
+
+	if len(result.Changes) != 1 {
+		t.Fatalf("len(Changes) = %d, want 1", len(result.Changes))
+	}
+
+	// Verify file was NOT modified
+	obj, _ := v.GetObject("book/test")
+	if _, exists := obj.Properties["isbn"]; exists {
+		t.Error("dry-run should not modify files")
+	}
+}
+
+func TestVault_MigrateObjects_NoChanges(t *testing.T) {
+	v := setupMigrateTestVault(t)
+
+	v.NewObject("book", "test")
+
+	// Schema unchanged — no migration needed
+	result, err := v.MigrateObjects("book", MigrateOptions{})
+	if err != nil {
+		t.Fatalf("MigrateObjects() error = %v", err)
+	}
+
+	if len(result.Changes) != 0 {
+		t.Errorf("len(Changes) = %d, want 0 (no changes needed)", len(result.Changes))
+	}
+}
+
+func TestVault_MigrateObjects_TypeNotFound(t *testing.T) {
+	v := setupMigrateTestVault(t)
+
+	_, err := v.MigrateObjects("nonexistent", MigrateOptions{})
+	if err == nil {
+		t.Fatal("expected error for nonexistent type, got nil")
+	}
+}
+
+func TestVault_MigrateObjects_RenameTargetNotInSchema(t *testing.T) {
+	v := setupMigrateTestVault(t)
+
+	_, err := v.MigrateObjects("book", MigrateOptions{
+		Renames: map[string]string{"status": "nonexistent"},
+	})
+	if err == nil {
+		t.Fatal("expected error when rename target not in schema, got nil")
+	}
+}
+
+func TestVault_MigrateObjects_RenameSourceStillInSchema(t *testing.T) {
+	v := setupMigrateTestVault(t)
+
+	// status still exists in schema — should error
+	_, err := v.MigrateObjects("book", MigrateOptions{
+		Renames: map[string]string{"status": "title"},
+	})
+	if err == nil {
+		t.Fatal("expected error when rename source still in schema, got nil")
+	}
+}
+
+func TestVault_MigrateObjects_DBNotOpen(t *testing.T) {
+	dir := t.TempDir()
+	v := NewVault(dir)
+	v.Init()
+
+	_, err := v.MigrateObjects("book", MigrateOptions{})
+	if err == nil {
+		t.Fatal("expected error when DB not opened, got nil")
+	}
+}

--- a/docs/src/content/docs/reference/migrate.md
+++ b/docs/src/content/docs/reference/migrate.md
@@ -1,0 +1,56 @@
+---
+title: tmd migrate
+description: Update objects to match the current type schema.
+sidebar:
+  order: 8.5
+---
+
+Migrates all objects of a given type to match the current schema. Adds missing properties (with defaults), removes obsolete ones, and optionally renames properties.
+
+```bash
+tmd migrate book
+tmd migrate book --dry-run
+tmd migrate book --rename old_field:new_field
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Preview changes without modifying files |
+| `--rename old:new` | Rename a property (repeatable) |
+
+## What it does
+
+For each object of the specified type:
+
+1. **Rename** — if `--rename` is provided, moves the old property value to the new name
+2. **Add** — properties in the schema but missing from the object are added with their default value
+3. **Remove** — properties in the object but not in the schema are removed
+
+Objects that already match the schema are skipped.
+
+## Examples
+
+Add a new `isbn` property to all books after updating the schema:
+
+```bash
+tmd migrate book
+#   book/clean-code: added [isbn]
+#   book/effective-go: added [isbn]
+# Migration complete: 2 object(s) updated.
+```
+
+Rename `status` to `reading_status` (update the schema first, then migrate):
+
+```bash
+tmd migrate book --rename status:reading_status
+```
+
+Preview changes before applying:
+
+```bash
+tmd migrate book --dry-run
+```
+
+> **Note:** The `--rename` flag requires that the new name exists in the current schema and the old name does not. Update the schema before running the migration.

--- a/docs/src/content/docs/zh-tw/reference/migrate.md
+++ b/docs/src/content/docs/zh-tw/reference/migrate.md
@@ -1,0 +1,56 @@
+---
+title: tmd migrate
+description: 更新物件以符合當前的 type schema。
+sidebar:
+  order: 8.5
+---
+
+將指定 type 的所有物件遷移至符合當前 schema。新增缺少的屬性（帶預設值）、移除過時的屬性，並可選擇性地重命名屬性。
+
+```bash
+tmd migrate book
+tmd migrate book --dry-run
+tmd migrate book --rename old_field:new_field
+```
+
+## Flags
+
+| Flag | 說明 |
+|------|------|
+| `--dry-run` | 預覽變更，不修改檔案 |
+| `--rename old:new` | 重命名屬性（可重複使用） |
+
+## 運作方式
+
+對指定 type 的每個物件：
+
+1. **重命名** — 若提供 `--rename`，將舊屬性的值搬移到新名稱
+2. **新增** — schema 中有但物件中缺少的屬性，以預設值新增
+3. **移除** — 物件中有但 schema 中沒有的屬性會被移除
+
+已經符合 schema 的物件會被跳過。
+
+## 範例
+
+更新 schema 後，為所有 book 新增 `isbn` 屬性：
+
+```bash
+tmd migrate book
+#   book/clean-code: added [isbn]
+#   book/effective-go: added [isbn]
+# Migration complete: 2 object(s) updated.
+```
+
+將 `status` 重命名為 `reading_status`（先更新 schema，再執行遷移）：
+
+```bash
+tmd migrate book --rename status:reading_status
+```
+
+先預覽變更再套用：
+
+```bash
+tmd migrate book --dry-run
+```
+
+> **注意：** `--rename` flag 要求新名稱存在於當前 schema，且舊名稱不存在。請先更新 schema 再執行遷移。


### PR DESCRIPTION
## Summary

- New `tmd migrate <type>` command to update all objects of a given type to match the current schema
- Adds missing properties with default values, removes obsolete properties
- Supports `--rename old:new` flag for renaming properties (repeatable)
- Supports `--dry-run` flag for previewing changes without modifying files

## Issue

Closes #22

## Test Plan

- [x] `TestVault_MigrateObjects_AddProperty` — new property added with default
- [x] `TestVault_MigrateObjects_RemoveProperty` — obsolete property removed
- [x] `TestVault_MigrateObjects_RenameProperty` — value moved to new name
- [x] `TestVault_MigrateObjects_DryRun` — no files modified
- [x] `TestVault_MigrateObjects_NoChanges` — objects already matching schema skipped
- [x] `TestVault_MigrateObjects_TypeNotFound` — error for unknown type
- [x] `TestVault_MigrateObjects_RenameTargetNotInSchema` — error validation
- [x] `TestVault_MigrateObjects_RenameSourceStillInSchema` — error validation
- [x] `TestVault_MigrateObjects_DBNotOpen` — error when vault not opened
- [x] All existing tests pass, `go vet` clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)