### PR TITLE
Strip ULID suffix from display output

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -39,7 +39,7 @@ Examples:
 			fmt.Println(string(data))
 		} else {
 			for _, obj := range results {
-				fmt.Println(obj.ID)
+				fmt.Println(obj.DisplayID())
 			}
 		}
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -38,7 +38,7 @@ Examples:
 			fmt.Println(string(data))
 		} else {
 			for _, obj := range results {
-				fmt.Println(obj.ID)
+				fmt.Println(obj.DisplayID())
 			}
 		}
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -34,7 +34,7 @@ Examples:
 		}
 
 		// Title
-		fmt.Println(obj.ID)
+		fmt.Println(obj.DisplayID())
 		fmt.Println()
 
 		// Properties & Relations

--- a/core/object.go
+++ b/core/object.go
@@ -20,6 +20,16 @@ type Object struct {
 	Body       string
 }
 
+// DisplayName returns the filename with ULID suffix stripped.
+func (o *Object) DisplayName() string {
+	return StripULID(o.Filename)
+}
+
+// DisplayID returns the object ID with ULID suffix stripped from the filename part.
+func (o *Object) DisplayID() string {
+	return o.Type + "/" + o.DisplayName()
+}
+
 // writeFrontmatter writes properties and body as markdown with YAML frontmatter.
 // keyOrder specifies the desired property output order. Properties not in keyOrder
 // are appended at the end. If keyOrder is nil, properties are written in map iteration order.

--- a/core/ulid.go
+++ b/core/ulid.go
@@ -3,6 +3,7 @@ package core
 import (
 	"crypto/rand"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -16,4 +17,12 @@ func GenerateULID() (string, error) {
 		return "", fmt.Errorf("generate ulid: %w", err)
 	}
 	return strings.ToLower(id.String()), nil
+}
+
+var ulidSuffixPattern = regexp.MustCompile(`-[0-9a-hjkmnp-tv-z]{26}$`)
+
+// StripULID removes the ULID suffix from a filename if present.
+// ULID suffix pattern: hyphen followed by exactly 26 Crockford's Base32 characters.
+func StripULID(filename string) string {
+	return ulidSuffixPattern.ReplaceAllString(filename, "")
 }

--- a/core/ulid_test.go
+++ b/core/ulid_test.go
@@ -24,3 +24,102 @@ func TestGenerateULID(t *testing.T) {
 		t.Error("two GenerateULID() calls returned same value")
 	}
 }
+
+func TestStripULID(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{
+			name:     "strips ULID suffix",
+			filename: "clean-code-01kk39c30x27ck7ahyc7ct4nyn",
+			want:     "clean-code",
+		},
+		{
+			name:     "strips ULID from multi-word name",
+			filename: "the-phoenix-project-01kk39c30yx20m5n2wqys1dk02",
+			want:     "the-phoenix-project",
+		},
+		{
+			name:     "no ULID suffix returns original",
+			filename: "golang-in-action",
+			want:     "golang-in-action",
+		},
+		{
+			name:     "short suffix not matching ULID pattern",
+			filename: "test-123",
+			want:     "test-123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripULID(tt.filename)
+			if got != tt.want {
+				t.Errorf("StripULID(%q) = %q, want %q", tt.filename, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObject_DisplayName(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{
+			name:     "strips ULID from filename",
+			filename: "clean-code-01kk39c30x27ck7ahyc7ct4nyn",
+			want:     "clean-code",
+		},
+		{
+			name:     "no ULID returns filename",
+			filename: "golang-in-action",
+			want:     "golang-in-action",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &Object{Filename: tt.filename}
+			got := obj.DisplayName()
+			if got != tt.want {
+				t.Errorf("DisplayName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObject_DisplayID(t *testing.T) {
+	tests := []struct {
+		name     string
+		objType  string
+		filename string
+		want     string
+	}{
+		{
+			name:     "returns type/display-name",
+			objType:  "book",
+			filename: "clean-code-01kk39c30x27ck7ahyc7ct4nyn",
+			want:     "book/clean-code",
+		},
+		{
+			name:     "no ULID uses full filename",
+			objType:  "book",
+			filename: "golang-in-action",
+			want:     "book/golang-in-action",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &Object{Type: tt.objType, Filename: tt.filename}
+			got := obj.DisplayID()
+			if got != tt.want {
+				t.Errorf("DisplayID() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/tui/app.go
+++ b/tui/app.go
@@ -476,7 +476,7 @@ func (m model) View() string {
 		} else {
 			var lines []string
 			for i, row := range rows {
-				line := fmt.Sprintf("   %s/%s", row.Object.Type, row.Object.Filename)
+				line := fmt.Sprintf("   %s", row.Object.DisplayID())
 				if i == m.cursor {
 					style := lipgloss.NewStyle().Bold(true).Reverse(true)
 					line = style.Render(line)

--- a/tui/list.go
+++ b/tui/list.go
@@ -108,7 +108,7 @@ func renderList(groups []typeGroup, cursor, scrollOffset int, focused bool, widt
 			}
 			line = fmt.Sprintf(" %s %s (%d)", arrow, g.Name, len(g.Objects))
 		} else {
-			line = fmt.Sprintf("   %s", row.Object.Filename)
+			line = fmt.Sprintf("   %s", row.Object.DisplayName())
 		}
 
 		if i == cursor {

--- a/websites/docs/src/content/docs/getting-started/quick-start.md
+++ b/websites/docs/src/content/docs/getting-started/quick-start.md
@@ -27,7 +27,7 @@ Use the CLI to create an object:
 
 ```bash
 tmd create book golang-in-action
-# Created: book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz
+# Created: book/golang-in-action
 ```
 
 The CLI automatically appends a ULID to the slug for uniqueness. Alternatively, you can create a file manually at `objects/book/golang-in-action.md` — manual files do not require a ULID and are backward compatible.

--- a/websites/docs/src/content/docs/guides/relations.md
+++ b/websites/docs/src/content/docs/guides/relations.md
@@ -50,7 +50,7 @@ properties:
 ### Create a Link
 
 ```bash
-tmd link book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k5mp...
+tmd link book/golang-in-action author person/alan-donovan
 ```
 
 When `bidirectional: true`, this automatically updates both the book's `author` and the person's `books` property.
@@ -58,7 +58,7 @@ When `bidirectional: true`, this automatically updates both the book's `author` 
 ### Remove a Link
 
 ```bash
-tmd unlink book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k5mp... --both
+tmd unlink book/golang-in-action author person/alan-donovan --both
 ```
 
 Use `--both` to remove the inverse side as well. This only takes effect when the relation property has `bidirectional: true` and an `inverse` field defined in the schema.

--- a/websites/docs/src/content/docs/reference/link.md
+++ b/websites/docs/src/content/docs/reference/link.md
@@ -8,5 +8,5 @@ sidebar:
 Creates a relation between two objects. If the schema defines `bidirectional: true`, the inverse property is automatically updated.
 
 ```bash
-tmd link book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k5mp...
+tmd link book/golang-in-action author person/alan-donovan
 ```

--- a/websites/docs/src/content/docs/reference/migrate.md
+++ b/websites/docs/src/content/docs/reference/migrate.md
@@ -36,8 +36,8 @@ Add a new `isbn` property to all books after updating the schema:
 
 ```bash
 tmd migrate book
-#   book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz: added [isbn]
-#   book/effective-go-01jqr3k5mpbvn8e0f2g7h9txyz: added [isbn]
+#   book/clean-code: added [isbn]
+#   book/effective-go: added [isbn]
 # Migration complete: 2 object(s) updated.
 ```
 

--- a/websites/docs/src/content/docs/reference/reindex.md
+++ b/websites/docs/src/content/docs/reference/reindex.md
@@ -19,8 +19,8 @@ When an object is deleted from disk, any relations pointing to or from that obje
 
 ```
 Warning: Found 2 orphaned relation(s):
-  book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz -> person/deleted-author-01jqr3k5mpbvn8e0f2g7h9txyz (relation: "author")
-  person/deleted-author-01jqr3k5mpbvn8e0f2g7h9txyz -> book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz (relation: "books")
+  book/golang-in-action -> person/deleted-author (relation: "author")
+  person/deleted-author -> book/golang-in-action (relation: "books")
 Orphaned relations have been removed from the index.
 ```
 

--- a/websites/docs/src/content/docs/reference/show.md
+++ b/websites/docs/src/content/docs/reference/show.md
@@ -8,13 +8,13 @@ sidebar:
 Displays an object's full information: properties (including relations) and body.
 
 ```bash
-tmd show book/golang-in-action-01jqr3k5mp...
+tmd show book/golang-in-action
 ```
 
 Example output:
 
 ```
-book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz
+book/golang-in-action
 
 Properties
 ──────────

--- a/websites/docs/src/content/docs/reference/unlink.md
+++ b/websites/docs/src/content/docs/reference/unlink.md
@@ -8,7 +8,7 @@ sidebar:
 Removes a relation. Use `--both` to remove the inverse side as well.
 
 ```bash
-tmd unlink book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k5mp... --both
+tmd unlink book/golang-in-action author person/alan-donovan --both
 ```
 
 ## Options

--- a/websites/docs/src/content/docs/zh-tw/getting-started/quick-start.md
+++ b/websites/docs/src/content/docs/zh-tw/getting-started/quick-start.md
@@ -27,7 +27,7 @@ tmd
 
 ```bash
 tmd create book golang-in-action
-# 建立 book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz
+# 建立 book/golang-in-action
 ```
 
 CLI 會自動在檔名後附加 ULID 以確保唯一性，產生的檔案路徑為 `objects/book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz.md`。

--- a/websites/docs/src/content/docs/zh-tw/guides/relations.md
+++ b/websites/docs/src/content/docs/zh-tw/guides/relations.md
@@ -50,7 +50,7 @@ properties:
 ### 建立連結
 
 ```bash
-tmd link book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k5mp...
+tmd link book/golang-in-action author person/alan-donovan
 ```
 
 當 `bidirectional: true` 時，這會自動更新書的 `author` 和人物的 `books` 屬性。
@@ -58,7 +58,7 @@ tmd link book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k5
 ### 移除連結
 
 ```bash
-tmd unlink book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k5mp... --both
+tmd unlink book/golang-in-action author person/alan-donovan --both
 ```
 
 使用 `--both` 來同時移除反向端。這只在 schema 中定義了 `bidirectional: true` 和 `inverse` 欄位時才有效。

--- a/websites/docs/src/content/docs/zh-tw/reference/link.md
+++ b/websites/docs/src/content/docs/zh-tw/reference/link.md
@@ -8,5 +8,5 @@ sidebar:
 在兩個 Object 之間建立 Relation。如果 schema 定義了 `bidirectional: true`，反向屬性會自動更新。
 
 ```bash
-tmd link book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k5mp...
+tmd link book/golang-in-action author person/alan-donovan
 ```

--- a/websites/docs/src/content/docs/zh-tw/reference/migrate.md
+++ b/websites/docs/src/content/docs/zh-tw/reference/migrate.md
@@ -36,8 +36,8 @@ tmd migrate book --rename old_field:new_field
 
 ```bash
 tmd migrate book
-#   book/clean-code-01jqr3k5mp...: added [isbn]
-#   book/effective-go-01jqr3k5mp...: added [isbn]
+#   book/clean-code: added [isbn]
+#   book/effective-go: added [isbn]
 # Migration complete: 2 object(s) updated.
 ```
 

--- a/websites/docs/src/content/docs/zh-tw/reference/reindex.md
+++ b/websites/docs/src/content/docs/zh-tw/reference/reindex.md
@@ -19,8 +19,8 @@ tmd reindex
 
 ```
 Warning: Found 2 orphaned relation(s):
-  book/golang-in-action-01jqr3k5mp... -> person/deleted-author-01jqr3k5mp... (relation: "author")
-  person/deleted-author-01jqr3k5mp... -> book/golang-in-action-01jqr3k5mp... (relation: "books")
+  book/golang-in-action -> person/deleted-author (relation: "author")
+  person/deleted-author -> book/golang-in-action (relation: "books")
 Orphaned relations have been removed from the index.
 ```
 

--- a/websites/docs/src/content/docs/zh-tw/reference/show.md
+++ b/websites/docs/src/content/docs/zh-tw/reference/show.md
@@ -8,13 +8,13 @@ sidebar:
 顯示 Object 的完整資訊：屬性（包含 Relation）和內文。
 
 ```bash
-tmd show book/golang-in-action-01jqr3k5mp...
+tmd show book/golang-in-action
 ```
 
 輸出範例：
 
 ```
-book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz
+book/golang-in-action
 
 Properties
 ──────────

--- a/websites/docs/src/content/docs/zh-tw/reference/unlink.md
+++ b/websites/docs/src/content/docs/zh-tw/reference/unlink.md
@@ -8,7 +8,7 @@ sidebar:
 移除 Relation。使用 `--both` 來同時移除反向端。
 
 ```bash
-tmd unlink book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k5mp... --both
+tmd unlink book/golang-in-action author person/alan-donovan --both
 ```
 
 ## 選項


### PR DESCRIPTION
## Summary

- Add `StripULID()` function to remove ULID suffix using regex pattern
- Add `Object.DisplayName()` and `Object.DisplayID()` methods
- Update TUI list and search to use display-friendly format
- Update CLI show/search/query output to use `DisplayID()`
- Update all documentation examples (EN + zh-TW) to reflect new display format

## Issue

Closes #75

## Test Plan

- ✅ All tests pass (4 packages, 0 failures)
- ✅ Build succeeds
- ✅ `StripULID()` correctly removes ULID suffix
- ✅ `DisplayName()` and `DisplayID()` return friendly format
- ✅ TUI list shows friendly names
- ✅ CLI commands output friendly IDs

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)