### PR TITLE
refactor(core,cmd): unify naming, extract helpers, improve error handling

### DIFF
--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -1,6 +1,11 @@
 package cmd
 
-import "github.com/typemd/typemd/core"
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/typemd/typemd/core"
+)
 
 // resolveVault creates a Vault with the given path, defaulting to "." if empty.
 func resolveVault(path string) *core.Vault {
@@ -9,3 +14,20 @@ func resolveVault(path string) *core.Vault {
 	}
 	return core.NewVault(path)
 }
+
+// printObjects prints objects as JSON or one DisplayID per line.
+func printObjects(objects []*core.Object, asJSON bool) error {
+	if asJSON {
+		data, err := json.MarshalIndent(objects, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal JSON: %w", err)
+		}
+		fmt.Println(string(data))
+	} else {
+		for _, obj := range objects {
+			fmt.Println(obj.DisplayID())
+		}
+	}
+	return nil
+}
+

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -31,19 +28,7 @@ Examples:
 			return err
 		}
 
-		if queryJSON {
-			data, err := json.MarshalIndent(results, "", "  ")
-			if err != nil {
-				return fmt.Errorf("marshal JSON: %w", err)
-			}
-			fmt.Println(string(data))
-		} else {
-			for _, obj := range results {
-				fmt.Println(obj.DisplayID())
-			}
-		}
-
-		return nil
+		return printObjects(results, queryJSON)
 	},
 }
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -30,19 +27,7 @@ Examples:
 			return err
 		}
 
-		if searchJSON {
-			data, err := json.MarshalIndent(results, "", "  ")
-			if err != nil {
-				return fmt.Errorf("marshal JSON: %w", err)
-			}
-			fmt.Println(string(data))
-		} else {
-			for _, obj := range results {
-				fmt.Println(obj.DisplayID())
-			}
-		}
-
-		return nil
+		return printObjects(results, searchJSON)
 	},
 }
 

--- a/core/display.go
+++ b/core/display.go
@@ -39,6 +39,8 @@ func (v *Vault) BuildDisplayProperties(obj *Object) ([]DisplayProperty, error) {
 		return nil, nil
 	}
 
+	// LoadType may fail for unknown types; nil schema is safe here because
+	// the code below skips schema-dependent logic when schema is nil.
 	schema, _ := v.LoadType(obj.Type)
 
 	// Build merged properties map (original + schema defaults) without mutating obj
@@ -61,7 +63,10 @@ func (v *Vault) BuildDisplayProperties(obj *Object) ([]DisplayProperty, error) {
 	}
 
 	// Get relations
-	relations, _ := v.ListRelations(obj.ID)
+	relations, err := v.ListRelations(obj.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list relations: %w", err)
+	}
 
 	// Build ordered properties
 	propKeys := OrderedPropKeys(merged, schema)
@@ -87,7 +92,10 @@ func (v *Vault) BuildDisplayProperties(obj *Object) ([]DisplayProperty, error) {
 	}
 
 	// Append backlinks (wiki-links pointing to this object)
-	backlinks, _ := v.ListBacklinks(obj.ID)
+	backlinks, err := v.ListBacklinks(obj.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list backlinks: %w", err)
+	}
 	for _, bl := range backlinks {
 		result = append(result, DisplayProperty{
 			Key:        BacklinksDisplayKey,

--- a/core/migrate.go
+++ b/core/migrate.go
@@ -99,7 +99,7 @@ func (v *Vault) MigrateObjects(typeName string, opts MigrateOptions) (*MigrateRe
 		}
 
 		if !opts.DryRun {
-			if err := v.writeObjectProperties(obj); err != nil {
+			if err := v.saveObjectFile(obj); err != nil {
 				return nil, fmt.Errorf("write object %s: %w", obj.ID, err)
 			}
 		}

--- a/core/object.go
+++ b/core/object.go
@@ -91,15 +91,6 @@ func parseFrontmatter(data []byte) (map[string]any, string, error) {
 	return props, body, nil
 }
 
-// schemaKeyOrder returns property names in schema-defined order.
-func schemaKeyOrder(schema *TypeSchema) []string {
-	keys := make([]string, len(schema.Properties))
-	for i, p := range schema.Properties {
-		keys[i] = p.Name
-	}
-	return keys
-}
-
 // NewObject creates a new object with the given type and filename.
 func (v *Vault) NewObject(typeName, filename string) (*Object, error) {
 	if v.db == nil {
@@ -136,7 +127,7 @@ func (v *Vault) NewObject(typeName, filename string) (*Object, error) {
 	}
 
 	// Write .md file (O_EXCL ensures atomic uniqueness check)
-	data, err := writeFrontmatter(props, "", schemaKeyOrder(schema))
+	data, err := writeFrontmatter(props, "", OrderedPropKeys(props, schema))
 	if err != nil {
 		return nil, fmt.Errorf("write frontmatter: %w", err)
 	}
@@ -177,13 +168,10 @@ func (v *Vault) NewObject(typeName, filename string) (*Object, error) {
 	}, nil
 }
 
-// writeObjectProperties writes object properties to both .md file and SQLite.
-func (v *Vault) writeObjectProperties(obj *Object) error {
-	var keyOrder []string
-	if schema, err := v.LoadType(obj.Type); err == nil {
-		keyOrder = schemaKeyOrder(schema)
-	}
-	data, err := writeFrontmatter(obj.Properties, obj.Body, keyOrder)
+// saveObjectFile writes object properties to both .md file and SQLite.
+func (v *Vault) saveObjectFile(obj *Object) error {
+	schema, _ := v.LoadType(obj.Type)
+	data, err := writeFrontmatter(obj.Properties, obj.Body, OrderedPropKeys(obj.Properties, schema))
 	if err != nil {
 		return fmt.Errorf("write frontmatter: %w", err)
 	}
@@ -230,7 +218,7 @@ func (v *Vault) SetProperty(id, key string, value any) error {
 
 	obj.Properties[key] = value
 
-	return v.writeObjectProperties(obj)
+	return v.saveObjectFile(obj)
 }
 
 // GetObject reads an object from its Markdown file.
@@ -266,6 +254,6 @@ func (v *Vault) SaveObject(obj *Object) error {
 	if v.db == nil {
 		return fmt.Errorf("vault not opened")
 	}
-	return v.writeObjectProperties(obj)
+	return v.saveObjectFile(obj)
 }
 

--- a/core/query_test.go
+++ b/core/query_test.go
@@ -234,8 +234,8 @@ func TestVault_SearchObjects_ByBody(t *testing.T) {
 		t.Fatalf("NewObject() error = %v", err)
 	}
 	obj.Body = "This book covers goroutines and channels."
-	if err := v.writeObjectProperties(obj); err != nil {
-		t.Fatalf("writeObjectProperties() error = %v", err)
+	if err := v.saveObjectFile(obj); err != nil {
+		t.Fatalf("saveObjectFile() error = %v", err)
 	}
 
 	v.NewObject("book", "other") //nolint:errcheck
@@ -330,8 +330,8 @@ func TestVault_SearchObjects_UpdateSync(t *testing.T) {
 
 	// UPDATE should sync FTS via trigger
 	obj.Body = "This chapter covers blockchain fundamentals."
-	if err := v.writeObjectProperties(obj); err != nil {
-		t.Fatalf("writeObjectProperties() error = %v", err)
+	if err := v.saveObjectFile(obj); err != nil {
+		t.Fatalf("saveObjectFile() error = %v", err)
 	}
 
 	results, err = v.SearchObjects("blockchain")
@@ -353,8 +353,8 @@ func TestVault_RebuildIndex(t *testing.T) {
 		t.Fatalf("NewObject() error = %v", err)
 	}
 	obj.Body = "concurrency patterns in Go"
-	if err := v.writeObjectProperties(obj); err != nil {
-		t.Fatalf("writeObjectProperties() error = %v", err)
+	if err := v.saveObjectFile(obj); err != nil {
+		t.Fatalf("saveObjectFile() error = %v", err)
 	}
 
 	if err := v.RebuildIndex(); err != nil {

--- a/core/relation.go
+++ b/core/relation.go
@@ -1,6 +1,12 @@
 package core
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+// errDuplicateRelation is returned when appending a value that already exists.
+var errDuplicateRelation = errors.New("duplicate relation value")
 
 // Relation represents a relationship record between two objects.
 type Relation struct {
@@ -33,6 +39,59 @@ func (v *Vault) ListRelations(objectID string) ([]Relation, error) {
 		rels = append(rels, r)
 	}
 	return rels, rows.Err()
+}
+
+// getRelationSlice extracts the existing []any from a property value.
+func getRelationSlice(props map[string]any, name string) []any {
+	existing, _ := props[name]
+	if existing == nil {
+		return nil
+	}
+	if arr, ok := existing.([]any); ok {
+		return arr
+	}
+	return nil
+}
+
+// appendRelationValue adds a value to a relation property.
+// For multiple relations, it appends to the existing array.
+// Returns an error if the value already exists in a multiple relation.
+func appendRelationValue(props map[string]any, name, value string, multiple bool) error {
+	if !multiple {
+		props[name] = value
+		return nil
+	}
+	arr := getRelationSlice(props, name)
+	for _, item := range arr {
+		if item == value {
+			return errDuplicateRelation
+		}
+	}
+	props[name] = append(arr, any(value))
+	return nil
+}
+
+// removeRelationValue removes a value from a relation property.
+// For multiple relations, it filters the value out of the existing array.
+func removeRelationValue(props map[string]any, name, value string, multiple bool) {
+	if !multiple {
+		if props[name] == value {
+			props[name] = nil
+		}
+		return
+	}
+	arr := getRelationSlice(props, name)
+	var newArr []any
+	for _, item := range arr {
+		if item != value {
+			newArr = append(newArr, item)
+		}
+	}
+	if len(newArr) == 0 {
+		props[name] = nil
+	} else {
+		props[name] = newArr
+	}
 }
 
 // findRelationProperty finds a relation property by name in a type schema.
@@ -77,26 +136,11 @@ func (v *Vault) LinkObjects(fromID, relName, toID string) error {
 	}
 
 	// Update source frontmatter
-	if relProp.Multiple {
-		existing, _ := fromObj.Properties[relName]
-		var arr []any
-		if existing != nil {
-			if existArr, ok := existing.([]any); ok {
-				arr = existArr
-			}
-		}
-		for _, item := range arr {
-			if item == toID {
-				return fmt.Errorf("relation already exists: %s -[%s]-> %s", fromID, relName, toID)
-			}
-		}
-		arr = append(arr, toID)
-		fromObj.Properties[relName] = arr
-	} else {
-		fromObj.Properties[relName] = toID
+	if err := appendRelationValue(fromObj.Properties, relName, toID, relProp.Multiple); err != nil {
+		return fmt.Errorf("relation already exists: %s -[%s]-> %s", fromID, relName, toID)
 	}
 
-	if err := v.writeObjectProperties(fromObj); err != nil {
+	if err := v.saveObjectFile(fromObj); err != nil {
 		return fmt.Errorf("write source object: %w", err)
 	}
 
@@ -121,21 +165,12 @@ func (v *Vault) LinkObjects(fromID, relName, toID string) error {
 			return fmt.Errorf("inverse relation %q not found in type %q", relProp.Inverse, toObj.Type)
 		}
 
-		if inverseProp.Multiple {
-			existing, _ := toObj.Properties[relProp.Inverse]
-			var arr []any
-			if existing != nil {
-				if existArr, ok := existing.([]any); ok {
-					arr = existArr
-				}
-			}
-			arr = append(arr, fromID)
-			toObj.Properties[relProp.Inverse] = arr
-		} else {
-			toObj.Properties[relProp.Inverse] = fromID
+		// Duplicate on inverse side is not an error (idempotent)
+		if err := appendRelationValue(toObj.Properties, relProp.Inverse, fromID, inverseProp.Multiple); err != nil && !errors.Is(err, errDuplicateRelation) {
+			return fmt.Errorf("set inverse relation: %w", err)
 		}
 
-		if err := v.writeObjectProperties(toObj); err != nil {
+		if err := v.saveObjectFile(toObj); err != nil {
 			return fmt.Errorf("write target object: %w", err)
 		}
 
@@ -175,26 +210,9 @@ func (v *Vault) UnlinkObjects(fromID, relName, toID string, both bool) error {
 	}
 
 	// Remove from source frontmatter
-	if relProp.Multiple {
-		existing, _ := fromObj.Properties[relName]
-		if existArr, ok := existing.([]any); ok {
-			var newArr []any
-			for _, item := range existArr {
-				if item != toID {
-					newArr = append(newArr, item)
-				}
-			}
-			if len(newArr) == 0 {
-				fromObj.Properties[relName] = nil
-			} else {
-				fromObj.Properties[relName] = newArr
-			}
-		}
-	} else {
-		fromObj.Properties[relName] = nil
-	}
+	removeRelationValue(fromObj.Properties, relName, toID, relProp.Multiple)
 
-	if err := v.writeObjectProperties(fromObj); err != nil {
+	if err := v.saveObjectFile(fromObj); err != nil {
 		return fmt.Errorf("write source object: %w", err)
 	}
 
@@ -224,26 +242,9 @@ func (v *Vault) UnlinkObjects(fromID, relName, toID string, both bool) error {
 			return fmt.Errorf("inverse relation %q not found in type %q", relProp.Inverse, toObj.Type)
 		}
 
-		if inverseProp.Multiple {
-			existing, _ := toObj.Properties[relProp.Inverse]
-			if existArr, ok := existing.([]any); ok {
-				var newArr []any
-				for _, item := range existArr {
-					if item != fromID {
-						newArr = append(newArr, item)
-					}
-				}
-				if len(newArr) == 0 {
-					toObj.Properties[relProp.Inverse] = nil
-				} else {
-					toObj.Properties[relProp.Inverse] = newArr
-				}
-			}
-		} else {
-			toObj.Properties[relProp.Inverse] = nil
-		}
+		removeRelationValue(toObj.Properties, relProp.Inverse, fromID, inverseProp.Multiple)
 
-		if err := v.writeObjectProperties(toObj); err != nil {
+		if err := v.saveObjectFile(toObj); err != nil {
 			return fmt.Errorf("write target object: %w", err)
 		}
 

--- a/core/validate_test.go
+++ b/core/validate_test.go
@@ -75,7 +75,7 @@ func TestValidateAllObjects_Invalid(t *testing.T) {
 		t.Fatalf("NewObject error = %v", err)
 	}
 	obj.Properties["rating"] = "not-a-number"
-	v.writeObjectProperties(obj)
+	v.saveObjectFile(obj)
 
 	result := ValidateAllObjects(v)
 	if errs, ok := result[obj.ID]; !ok || len(errs) == 0 {


### PR DESCRIPTION
## Summary

- Extracted relation array operation helpers to eliminate 60+ lines of duplicated code
- Unified property key ordering by removing duplicate `schemaKeyOrder` function
- Renamed `writeObjectProperties` → `saveObjectFile` for clearer semantics
- Fixed error handling in `BuildDisplayProperties` (now propagates DB errors)
- Extracted shared `printObjects` helper for query/search commands

## Issue

Closes #56

## Test Plan

- [x] `go test ./...` — all pass (cmd, core, mcp, tui)
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues
- [x] Manual: verified existing tests cover refactored code paths