### PR TITLE
feat(core): support prefix matching for object IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ tmd --vault /path/to/vault
 tmd object create book clean-code
 # → Created book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz
 
-# Show object detail (use the full ID from create output)
-tmd object show book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz
+# Show object detail (prefix matching — no need to type the full ULID)
+tmd object show book/clean-code
 
 # List all objects
 tmd object list
@@ -83,11 +83,11 @@ tmd query "type=book" --json
 # Full-text search
 tmd search "concurrency"
 
-# Link two objects (use full IDs)
-tmd relation link book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k8yz...
+# Link two objects (prefix matching supported)
+tmd relation link book/golang-in-action author person/alan-donovan
 
 # Unlink (with --both to remove inverse side too)
-tmd relation unlink book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k8yz... --both
+tmd relation unlink book/golang-in-action author person/alan-donovan --both
 
 # Sync files to DB and rebuild search index (only needed after manual edits)
 tmd reindex

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -69,8 +69,8 @@ tmd --vault /path/to/vault
 tmd object create book clean-code
 # → Created book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz
 
-# 顯示 Object 詳情（使用 create 輸出的完整 ID）
-tmd object show book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz
+# 顯示 Object 詳情（支援前綴匹配，不需要輸入完整 ULID）
+tmd object show book/clean-code
 
 # 列出所有 Object
 tmd object list
@@ -83,11 +83,11 @@ tmd query "type=book" --json
 # 全文搜尋
 tmd search "concurrency"
 
-# 連結兩個 Object（使用完整 ID）
-tmd relation link book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k8yz...
+# 連結兩個 Object（支援前綴匹配）
+tmd relation link book/golang-in-action author person/alan-donovan
 
 # 取消連結（使用 --both 同時移除反向端）
-tmd relation unlink book/golang-in-action-01jqr3k5mp... author person/alan-donovan-01jqr3k8yz... --both
+tmd relation unlink book/golang-in-action author person/alan-donovan --both
 
 # 同步檔案到資料庫並重建搜尋索引（只在手動編輯後需要）
 tmd reindex

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -9,7 +9,15 @@ import (
 var linkCmd = &cobra.Command{
 	Use:   "link <from-id> <relation> <to-id>",
 	Short: "Link two objects with a relation",
-	Args:  cobra.ExactArgs(3),
+	Long: `Create a relation between two objects.
+
+Supports prefix matching — you can omit the ULID suffix if the prefix
+uniquely identifies an object.
+
+Examples:
+  tmd relation link book/clean-code author person/robert-martin
+  tmd relation link book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz author person/robert-martin-01jqr3k8yznw2a4dbx6t7c9fpq`,
+	Args: cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vault := resolveVault(vaultPath)
 		if err := vault.Open(); err != nil {
@@ -17,7 +25,15 @@ var linkCmd = &cobra.Command{
 		}
 		defer vault.Close()
 
-		fromID, relName, toID := args[0], args[1], args[2]
+		relName := args[1]
+		fromID, err := vault.ResolveID(args[0])
+		if err != nil {
+			return err
+		}
+		toID, err := vault.ResolveID(args[2])
+		if err != nil {
+			return err
+		}
 		if err := vault.LinkObjects(fromID, relName, toID); err != nil {
 			return err
 		}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -13,9 +13,13 @@ var showCmd = &cobra.Command{
 	Short: "Show object detail (properties, relations, body)",
 	Long: `Display an object's properties, relations, and body content.
 
+Supports prefix matching — you can omit the ULID suffix if the prefix
+uniquely identifies an object.
+
 Examples:
+  tmd object show book/clean-code
   tmd object show book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz
-  tmd object show person/robert-martin-01jqr3k8yznw2a4dbx6t7c9fpq`,
+  tmd object show person/robert-martin`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vault := resolveVault(vaultPath)
@@ -24,7 +28,7 @@ Examples:
 		}
 		defer vault.Close()
 
-		obj, err := vault.GetObject(args[0])
+		obj, err := vault.ResolveObject(args[0])
 		if err != nil {
 			return err
 		}

--- a/cmd/unlink.go
+++ b/cmd/unlink.go
@@ -9,7 +9,15 @@ import (
 var unlinkCmd = &cobra.Command{
 	Use:   "unlink <from-id> <relation> <to-id>",
 	Short: "Remove a relation between two objects",
-	Args:  cobra.ExactArgs(3),
+	Long: `Remove a relation between two objects.
+
+Supports prefix matching — you can omit the ULID suffix if the prefix
+uniquely identifies an object.
+
+Examples:
+  tmd relation unlink book/clean-code author person/robert-martin
+  tmd relation unlink book/clean-code author person/robert-martin --both`,
+	Args: cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		both, _ := cmd.Flags().GetBool("both")
 
@@ -19,7 +27,15 @@ var unlinkCmd = &cobra.Command{
 		}
 		defer vault.Close()
 
-		fromID, relName, toID := args[0], args[1], args[2]
+		relName := args[1]
+		fromID, err := vault.ResolveID(args[0])
+		if err != nil {
+			return err
+		}
+		toID, err := vault.ResolveID(args[2])
+		if err != nil {
+			return err
+		}
 		if err := vault.UnlinkObjects(fromID, relName, toID, both); err != nil {
 			return err
 		}

--- a/core/bdd_steps_test.go
+++ b/core/bdd_steps_test.go
@@ -39,6 +39,9 @@ type domainContext struct {
 
 	// wikilink results
 	wikiLinks []StoredWikiLink
+
+	// resolve results
+	resolvedID string
 }
 
 func newDomainContext() *domainContext {
@@ -735,6 +738,75 @@ func (dc *domainContext) theWikiLinkDisplayTextShouldBe(expected string) error {
 	return nil
 }
 
+// ── Resolve steps ───────────────────────────────────────────────────────────
+
+func (dc *domainContext) iResolveTheObjectByItsFullID() {
+	if dc.currentObject == nil {
+		dc.lastErr = fmt.Errorf("no current object")
+		return
+	}
+	dc.resolvedID, dc.lastErr = dc.vault.ResolveID(dc.currentObject.ID)
+}
+
+func (dc *domainContext) theResolvedIDShouldMatchTheOriginal() error {
+	if dc.resolvedID != dc.currentObject.ID {
+		return fmt.Errorf("resolved ID = %q, want %q", dc.resolvedID, dc.currentObject.ID)
+	}
+	return nil
+}
+
+func (dc *domainContext) iResolveTheObjectByPrefix(prefix string) {
+	obj, err := dc.vault.ResolveObject(prefix)
+	dc.lastErr = err
+	if err == nil {
+		dc.retrieved = obj
+	}
+}
+
+func (dc *domainContext) theResolvedObjectShouldMatchTheCreatedOne() error {
+	if dc.retrieved == nil {
+		return fmt.Errorf("no resolved object")
+	}
+	if dc.currentObject == nil {
+		return fmt.Errorf("no current object to compare")
+	}
+	if dc.retrieved.ID != dc.currentObject.ID {
+		return fmt.Errorf("resolved ID = %q, want %q", dc.retrieved.ID, dc.currentObject.ID)
+	}
+	return nil
+}
+
+func (dc *domainContext) iResolveTheObjectByAPartialULIDPrefix() {
+	if dc.currentObject == nil {
+		dc.lastErr = fmt.Errorf("no current object")
+		return
+	}
+	// Use type + display name + first 4 chars of ULID as partial prefix
+	displayName := dc.currentObject.DisplayName()
+	ulidPart := strings.TrimPrefix(dc.currentObject.Filename, displayName+"-")
+	partial := ulidPart[:4]
+	prefix := dc.currentObject.Type + "/" + displayName + "-" + partial
+	obj, err := dc.vault.ResolveObject(prefix)
+	dc.lastErr = err
+	if err == nil {
+		dc.retrieved = obj
+	}
+}
+
+func (dc *domainContext) anAmbiguousMatchErrorShouldOccurWithNCandidates(expected int) error {
+	if dc.lastErr == nil {
+		return fmt.Errorf("expected AmbiguousMatchError, got nil")
+	}
+	ambErr, ok := dc.lastErr.(*AmbiguousMatchError)
+	if !ok {
+		return fmt.Errorf("expected *AmbiguousMatchError, got %T: %v", dc.lastErr, dc.lastErr)
+	}
+	if len(ambErr.Matches) != expected {
+		return fmt.Errorf("candidates = %d, want %d", len(ambErr.Matches), expected)
+	}
+	return nil
+}
+
 // ── Common steps ────────────────────────────────────────────────────────────
 
 func (dc *domainContext) anErrorShouldOccur() error {
@@ -848,6 +920,14 @@ func initDomainSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^"([^"]*)" wiki-link should point to "([^"]*)"$`, dc.wikiLinkShouldPointTo)
 	ctx.Step(`^"([^"]*)" should have (\d+) backlinks$`, dc.shouldHaveNBacklinks)
 	ctx.Step(`^the wiki-link display text should be "([^"]*)"$`, dc.theWikiLinkDisplayTextShouldBe)
+
+	// Resolve steps
+	ctx.Step(`^I resolve the object by its full ID$`, dc.iResolveTheObjectByItsFullID)
+	ctx.Step(`^the resolved ID should match the original$`, dc.theResolvedIDShouldMatchTheOriginal)
+	ctx.Step(`^I resolve the object by prefix "([^"]*)"$`, dc.iResolveTheObjectByPrefix)
+	ctx.Step(`^the resolved object should match the created one$`, dc.theResolvedObjectShouldMatchTheCreatedOne)
+	ctx.Step(`^I resolve the object by a partial ULID prefix$`, dc.iResolveTheObjectByAPartialULIDPrefix)
+	ctx.Step(`^an ambiguous match error should occur with (\d+) candidates$`, dc.anAmbiguousMatchErrorShouldOccurWithNCandidates)
 
 	// Common steps
 	ctx.Step(`^an error should occur$`, dc.anErrorShouldOccur)

--- a/core/features/resolve.feature
+++ b/core/features/resolve.feature
@@ -1,0 +1,31 @@
+Feature: Resolve object by prefix
+  Users can type a shortened object ID (e.g. "book/clean-code") and have it
+  resolve to the full ULID-suffixed ID.
+
+  Background:
+    Given a vault is ready
+
+  Scenario: Resolve object by exact full ID
+    Given a "book" object named "clean-code" exists
+    When I resolve the object by its full ID
+    Then the resolved ID should match the original
+
+  Scenario: Resolve object by name prefix without ULID
+    Given a "book" object named "clean-code" exists
+    When I resolve the object by prefix "book/clean-code"
+    Then the resolved object should match the created one
+
+  Scenario: Resolve object by partial ULID prefix
+    Given a "book" object named "clean-code" exists
+    When I resolve the object by a partial ULID prefix
+    Then the resolved object should match the created one
+
+  Scenario: Ambiguous prefix matches multiple objects
+    Given a "book" object named "clean-code" exists
+    And a "book" object named "clean-code-second-edition" exists
+    When I resolve the object by prefix "book/clean-code"
+    Then an ambiguous match error should occur with 2 candidates
+
+  Scenario: No object matches prefix
+    When I resolve the object by prefix "book/nonexistent"
+    Then an error should occur

--- a/core/object.go
+++ b/core/object.go
@@ -5,11 +5,27 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/adrg/frontmatter"
 	"gopkg.in/yaml.v3"
 )
+
+// AmbiguousMatchError is returned when a prefix matches multiple objects.
+type AmbiguousMatchError struct {
+	Prefix  string
+	Matches []string
+}
+
+func (e *AmbiguousMatchError) Error() string {
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "ambiguous object ID %q matches %d objects:", e.Prefix, len(e.Matches))
+	for _, m := range e.Matches {
+		fmt.Fprintf(&buf, "\n  %s", m)
+	}
+	return buf.String()
+}
 
 // Object represents a typemd object.
 type Object struct {
@@ -247,6 +263,57 @@ func (v *Vault) GetObject(id string) (*Object, error) {
 		Properties: props,
 		Body:       body,
 	}, nil
+}
+
+// ResolveID resolves a (possibly abbreviated) object ID to the full ID.
+// The input must be in "type/name" format. Exact matches take priority.
+// If no exact match, a filesystem glob is used to find prefix matches.
+func (v *Vault) ResolveID(prefix string) (string, error) {
+	parts := strings.SplitN(prefix, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", fmt.Errorf("invalid object ID format: %q", prefix)
+	}
+	typeName, namePrefix := parts[0], parts[1]
+
+	// 1. Exact match
+	exactPath := v.ObjectPath(typeName, namePrefix)
+	if _, err := os.Stat(exactPath); err == nil {
+		return prefix, nil
+	}
+
+	// 2. Glob for prefix matches
+	pattern := filepath.Join(v.ObjectDir(typeName), namePrefix+"*.md")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", fmt.Errorf("glob error: %w", err)
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("no object found matching %q", prefix)
+	case 1:
+		// Extract ID from path: strip dir prefix and .md suffix
+		base := filepath.Base(matches[0])
+		filename := strings.TrimSuffix(base, ".md")
+		return typeName + "/" + filename, nil
+	default:
+		candidates := make([]string, len(matches))
+		for i, m := range matches {
+			base := filepath.Base(m)
+			filename := strings.TrimSuffix(base, ".md")
+			candidates[i] = typeName + "/" + filename
+		}
+		return "", &AmbiguousMatchError{Prefix: prefix, Matches: candidates}
+	}
+}
+
+// ResolveObject resolves a prefix to a full ID and returns the object.
+func (v *Vault) ResolveObject(prefix string) (*Object, error) {
+	id, err := v.ResolveID(prefix)
+	if err != nil {
+		return nil, err
+	}
+	return v.GetObject(id)
 }
 
 // SaveObject persists an object's properties and body to the .md file and updates SQLite.

--- a/core/object_test.go
+++ b/core/object_test.go
@@ -434,3 +434,113 @@ func TestVault_SaveObject_ErrorWhenNotOpened(t *testing.T) {
 		t.Fatal("expected error when vault not opened, got nil")
 	}
 }
+
+func TestAmbiguousMatchError_Format(t *testing.T) {
+	err := &AmbiguousMatchError{
+		Prefix:  "book/clean-code",
+		Matches: []string{"book/clean-code-01abc", "book/clean-code-second-02xyz"},
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, `ambiguous object ID "book/clean-code" matches 2 objects:`) {
+		t.Errorf("unexpected error message: %s", msg)
+	}
+	if !strings.Contains(msg, "  book/clean-code-01abc") {
+		t.Errorf("expected match listed: %s", msg)
+	}
+}
+
+func TestVault_ResolveID_InvalidFormat(t *testing.T) {
+	v := setupTestVault(t)
+
+	for _, input := range []string{"no-slash", "/missing-type", "missing-name/", ""} {
+		_, err := v.ResolveID(input)
+		if err == nil {
+			t.Errorf("ResolveID(%q) expected error, got nil", input)
+		}
+	}
+}
+
+func TestVault_ResolveID_TypeDirNotExist(t *testing.T) {
+	v := setupTestVault(t)
+
+	_, err := v.ResolveID("nonexistent/test")
+	if err == nil {
+		t.Fatal("expected error for missing type directory, got nil")
+	}
+}
+
+func TestVault_ResolveID_ExactMatch(t *testing.T) {
+	v := setupTestVault(t)
+
+	obj, err := v.NewObject("book", "test-resolve")
+	if err != nil {
+		t.Fatalf("NewObject() error = %v", err)
+	}
+
+	resolved, err := v.ResolveID(obj.ID)
+	if err != nil {
+		t.Fatalf("ResolveID() error = %v", err)
+	}
+	if resolved != obj.ID {
+		t.Errorf("resolved = %q, want %q", resolved, obj.ID)
+	}
+}
+
+func TestVault_ResolveID_PrefixMatch(t *testing.T) {
+	v := setupTestVault(t)
+
+	obj, err := v.NewObject("book", "unique-prefix")
+	if err != nil {
+		t.Fatalf("NewObject() error = %v", err)
+	}
+
+	resolved, err := v.ResolveID("book/unique-prefix")
+	if err != nil {
+		t.Fatalf("ResolveID() error = %v", err)
+	}
+	if resolved != obj.ID {
+		t.Errorf("resolved = %q, want %q", resolved, obj.ID)
+	}
+}
+
+func TestVault_ResolveID_AmbiguousMatch(t *testing.T) {
+	v := setupTestVault(t)
+
+	_, err := v.NewObject("book", "ambig")
+	if err != nil {
+		t.Fatalf("NewObject() error = %v", err)
+	}
+	_, err = v.NewObject("book", "ambig")
+	if err != nil {
+		t.Fatalf("NewObject() error = %v", err)
+	}
+
+	_, err = v.ResolveID("book/ambig")
+	if err == nil {
+		t.Fatal("expected AmbiguousMatchError, got nil")
+	}
+	ambErr, ok := err.(*AmbiguousMatchError)
+	if !ok {
+		t.Fatalf("expected *AmbiguousMatchError, got %T: %v", err, err)
+	}
+	if len(ambErr.Matches) != 2 {
+		t.Errorf("matches = %d, want 2", len(ambErr.Matches))
+	}
+}
+
+func TestVault_ResolveObject(t *testing.T) {
+	v := setupTestVault(t)
+
+	created, err := v.NewObject("book", "resolve-obj")
+	if err != nil {
+		t.Fatalf("NewObject() error = %v", err)
+	}
+
+	obj, err := v.ResolveObject("book/resolve-obj")
+	if err != nil {
+		t.Fatalf("ResolveObject() error = %v", err)
+	}
+	if obj.ID != created.ID {
+		t.Errorf("ID = %q, want %q", obj.ID, created.ID)
+	}
+}

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -21,10 +21,10 @@ func registerTools(s *server.MCPServer, vault *core.Vault) {
 	s.AddTool(searchTool, searchHandler(vault))
 
 	getObjectTool := mcplib.NewTool("get_object",
-		mcplib.WithDescription("Get an object by its ID (e.g. book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz)"),
+		mcplib.WithDescription("Get an object by its full or abbreviated ID. Supports prefix matching (e.g. book/clean-code resolves to the full ULID-suffixed ID)."),
 		mcplib.WithString("id",
 			mcplib.Required(),
-			mcplib.Description("Object ID in type/slug-ulid format"),
+			mcplib.Description("Object ID or prefix (e.g. book/clean-code or book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz)"),
 		),
 	)
 	s.AddTool(getObjectTool, getObjectHandler(vault))
@@ -81,7 +81,7 @@ func getObjectHandler(vault *core.Vault) server.ToolHandlerFunc {
 			return mcplib.NewToolResultError(err.Error()), nil
 		}
 
-		obj, err := vault.GetObject(id)
+		obj, err := vault.ResolveObject(id)
 		if err != nil {
 			return mcplib.NewToolResultError(fmt.Sprintf("get object failed: %v", err)), nil
 		}

--- a/websites/docs/src/content/docs/reference/link.md
+++ b/websites/docs/src/content/docs/reference/link.md
@@ -7,6 +7,8 @@ sidebar:
 
 Creates a relation between two objects. If the schema defines `bidirectional: true`, the inverse property is automatically updated.
 
+Object IDs support prefix matching — you can omit the ULID suffix if the prefix uniquely identifies an object.
+
 ```bash
 tmd relation link book/golang-in-action author person/alan-donovan
 ```

--- a/websites/docs/src/content/docs/reference/show.md
+++ b/websites/docs/src/content/docs/reference/show.md
@@ -7,6 +7,8 @@ sidebar:
 
 Displays an object's full information: properties (including relations and backlinks) and body.
 
+Supports prefix matching — you can omit the ULID suffix if the prefix uniquely identifies an object. If multiple objects match, the command displays a disambiguation list.
+
 ```bash
 tmd object show book/golang-in-action
 ```

--- a/websites/docs/src/content/docs/reference/unlink.md
+++ b/websites/docs/src/content/docs/reference/unlink.md
@@ -7,6 +7,8 @@ sidebar:
 
 Removes a relation. Use `--both` to remove the inverse side as well.
 
+Object IDs support prefix matching — you can omit the ULID suffix if the prefix uniquely identifies an object.
+
 ```bash
 tmd relation unlink book/golang-in-action author person/alan-donovan --both
 ```

--- a/websites/docs/src/content/docs/zh-tw/reference/link.md
+++ b/websites/docs/src/content/docs/zh-tw/reference/link.md
@@ -7,6 +7,8 @@ sidebar:
 
 在兩個 Object 之間建立 Relation。如果 schema 定義了 `bidirectional: true`，反向屬性會自動更新。
 
+Object ID 支援前綴匹配 — 可以省略 ULID 後綴，只要前綴能唯一識別 Object 即可。
+
 ```bash
 tmd relation link book/golang-in-action author person/alan-donovan
 ```

--- a/websites/docs/src/content/docs/zh-tw/reference/show.md
+++ b/websites/docs/src/content/docs/zh-tw/reference/show.md
@@ -7,6 +7,8 @@ sidebar:
 
 顯示 Object 的完整資訊：屬性（包含 Relation 和反向連結）和內文。
 
+支援前綴匹配 — 可以省略 ULID 後綴，只要前綴能唯一識別 Object 即可。如果有多個 Object 匹配，會顯示候選清單。
+
 ```bash
 tmd object show book/golang-in-action
 ```

--- a/websites/docs/src/content/docs/zh-tw/reference/unlink.md
+++ b/websites/docs/src/content/docs/zh-tw/reference/unlink.md
@@ -7,6 +7,8 @@ sidebar:
 
 移除 Relation。使用 `--both` 來同時移除反向端。
 
+Object ID 支援前綴匹配 — 可以省略 ULID 後綴，只要前綴能唯一識別 Object 即可。
+
 ```bash
 tmd relation unlink book/golang-in-action author person/alan-donovan --both
 ```


### PR DESCRIPTION
## Summary

- Add `ResolveID()` and `ResolveObject()` methods to `Vault` for prefix-based object ID resolution via filesystem glob
- Add `AmbiguousMatchError` type returned when a prefix matches multiple objects
- Update CLI commands (`show`, `link`, `unlink`) and MCP `get_object` handler to use prefix resolution
- Update README, reference docs (en/zh-tw) to document prefix matching support

## Issue

Closes #72

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [x] Manual: `tmd object create book clean-code`, then `tmd object show book/clean-code` resolves correctly
- [x] Manual: Create two objects with similar names, verify ambiguous error is displayed