### PR TITLE
feat(core): filter undefined properties during sync

### DIFF
--- a/core/bdd_steps_test.go
+++ b/core/bdd_steps_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -950,6 +951,88 @@ func (dc *domainContext) theSchemaShouldUseSelectInsteadOfEnum(typeName string) 
 	return fmt.Errorf("no select property found in schema %q", typeName)
 }
 
+// ── Property filtering steps ────────────────────────────────────────────────
+
+func (dc *domainContext) aTypeSchemaWithProperties(typeName, propList string) {
+	props := strings.Split(propList, ",")
+	var yamlProps string
+	for _, p := range props {
+		yamlProps += fmt.Sprintf("  - name: %s\n    type: string\n", strings.TrimSpace(p))
+	}
+	schema := fmt.Sprintf("name: %s\nproperties:\n%s", typeName, yamlProps)
+	os.WriteFile(filepath.Join(dc.vault.TypesDir(), typeName+".yaml"), []byte(schema), 0644)
+}
+
+func (dc *domainContext) aRawObjectFileWithProperties(relPath string, table *godog.Table) {
+	var yamlContent string
+	for _, row := range table.Rows[1:] { // skip header
+		yamlContent += fmt.Sprintf("%s: %s\n", row.Cells[0].Value, row.Cells[1].Value)
+	}
+	content := fmt.Sprintf("---\n%s---\nSome body content.\n", yamlContent)
+
+	fullPath := filepath.Join(dc.vault.ObjectsDir(), relPath)
+	os.MkdirAll(filepath.Dir(fullPath), 0755)
+	os.WriteFile(fullPath, []byte(content), 0644)
+}
+
+func (dc *domainContext) getIndexedProperties(objectID string) (map[string]any, error) {
+	var propsJSON string
+	err := dc.vault.db.QueryRow("SELECT properties FROM objects WHERE id = ?", objectID).Scan(&propsJSON)
+	if err != nil {
+		return nil, fmt.Errorf("query properties for %s: %v", objectID, err)
+	}
+	var props map[string]any
+	if err := json.Unmarshal([]byte(propsJSON), &props); err != nil {
+		return nil, fmt.Errorf("unmarshal properties for %s: %v", objectID, err)
+	}
+	return props, nil
+}
+
+func (dc *domainContext) theIndexedPropertiesForShouldContain(objectID, key string) error {
+	props, err := dc.getIndexedProperties(objectID)
+	if err != nil {
+		return err
+	}
+	if _, ok := props[key]; !ok {
+		return fmt.Errorf("indexed properties for %s do not contain %q, got: %v", objectID, key, props)
+	}
+	return nil
+}
+
+func (dc *domainContext) theIndexedPropertiesForShouldNotContain(objectID, key string) error {
+	props, err := dc.getIndexedProperties(objectID)
+	if err != nil {
+		return err
+	}
+	if _, ok := props[key]; ok {
+		return fmt.Errorf("indexed properties for %s should not contain %q, got: %v", objectID, key, props)
+	}
+	return nil
+}
+
+func (dc *domainContext) theIndexedPropertiesForShouldBeEmpty(objectID string) error {
+	props, err := dc.getIndexedProperties(objectID)
+	if err != nil {
+		return err
+	}
+	if len(props) != 0 {
+		return fmt.Errorf("expected empty properties for %s, got: %v", objectID, props)
+	}
+	return nil
+}
+
+func (dc *domainContext) theFileShouldStillContainInFrontmatter(relPath, expected string) error {
+	fullPath := filepath.Join(dc.vault.ObjectsDir(), relPath)
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return fmt.Errorf("read file %s: %v", relPath, err)
+	}
+	if !strings.Contains(string(data), expected) {
+		return fmt.Errorf("file %s does not contain %q", relPath, expected)
+	}
+	return nil
+}
+
 // ── Common steps ────────────────────────────────────────────────────────────
 
 func (dc *domainContext) anErrorShouldOccur() error {
@@ -1084,6 +1167,14 @@ func initDomainSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the object should have validation errors$`, dc.theObjectShouldHaveValidationErrors)
 	ctx.Step(`^I migrate schemas$`, dc.iMigrateSchemas)
 	ctx.Step(`^the "([^"]*)" schema should use select instead of enum$`, dc.theSchemaShouldUseSelectInsteadOfEnum)
+
+	// Property filtering steps
+	ctx.Step(`^a type schema "([^"]*)" with properties "([^"]*)"$`, dc.aTypeSchemaWithProperties)
+	ctx.Step(`^a raw object file "([^"]*)" with properties:$`, dc.aRawObjectFileWithProperties)
+	ctx.Step(`^the indexed properties for "([^"]*)" should contain "([^"]*)"$`, dc.theIndexedPropertiesForShouldContain)
+	ctx.Step(`^the indexed properties for "([^"]*)" should not contain "([^"]*)"$`, dc.theIndexedPropertiesForShouldNotContain)
+	ctx.Step(`^the indexed properties for "([^"]*)" should be empty$`, dc.theIndexedPropertiesForShouldBeEmpty)
+	ctx.Step(`^the file "([^"]*)" should still contain "([^"]*)" in frontmatter$`, dc.theFileShouldStillContainInFrontmatter)
 
 	// Common steps
 	ctx.Step(`^an error should occur$`, dc.anErrorShouldOccur)

--- a/core/features/property_filtering.feature
+++ b/core/features/property_filtering.feature
@@ -1,0 +1,46 @@
+Feature: Property filtering during sync
+  As a tmd user
+  I want sync to only index schema-defined properties
+  So that the type schema is the single source of truth for managed properties
+
+  Background:
+    Given a vault is ready
+
+  Scenario: Sync filters out undefined properties
+    Given a type schema "book" with properties "title,status,rating"
+    And a raw object file "book/clean-code.md" with properties:
+      | key    | value      |
+      | title  | Clean Code |
+      | status | reading    |
+      | mood   | happy      |
+    When I sync the index
+    Then the indexed properties for "book/clean-code" should contain "title"
+    And the indexed properties for "book/clean-code" should contain "status"
+    And the indexed properties for "book/clean-code" should not contain "mood"
+
+  Scenario: Object with only undefined properties stores empty object
+    Given a type schema "book" with properties "title,status,rating"
+    And a raw object file "book/mystery.md" with properties:
+      | key   | value |
+      | mood  | happy |
+      | color | blue  |
+    When I sync the index
+    Then the indexed properties for "book/mystery" should be empty
+
+  Scenario: Object type without schema retains all properties
+    And a raw object file "recipe/pasta.md" with properties:
+      | key  | value |
+      | name | Pasta |
+      | time | 30min |
+    When I sync the index
+    Then the indexed properties for "recipe/pasta" should contain "name"
+    And the indexed properties for "recipe/pasta" should contain "time"
+
+  Scenario: Frontmatter file is not modified during sync
+    Given a type schema "book" with properties "title,status,rating"
+    And a raw object file "book/clean-code.md" with properties:
+      | key    | value      |
+      | title  | Clean Code |
+      | mood   | happy      |
+    When I sync the index
+    Then the file "book/clean-code.md" should still contain "mood" in frontmatter

--- a/core/sync.go
+++ b/core/sync.go
@@ -36,6 +36,10 @@ func (v *Vault) SyncIndex() (*SyncResult, error) {
 	diskIDs := make(map[string]bool)
 	diskBodies := make(map[string]string)
 
+	// Cache loaded type schemas and their property name sets per type
+	schemaCache := make(map[string]*TypeSchema)
+	propertyNameCache := make(map[string]map[string]bool)
+
 	objsDir := v.ObjectsDir()
 	if _, err := os.Stat(objsDir); os.IsNotExist(err) {
 		// No objects directory — just clean DB and return
@@ -74,6 +78,27 @@ func (v *Vault) SyncIndex() (*SyncResult, error) {
 		props, body, err := parseFrontmatter(data)
 		if err != nil {
 			return nil // skip unparseable files
+		}
+
+		// Filter properties by type schema (only index schema-defined keys)
+		if _, cached := schemaCache[typeName]; !cached {
+			schema, err := v.LoadType(typeName)
+			if err != nil {
+				// No schema for this type — store nil to skip filtering
+				schemaCache[typeName] = nil
+			} else {
+				schemaCache[typeName] = schema
+				propertyNameCache[typeName] = schema.PropertyNames()
+			}
+		}
+		if allowed := propertyNameCache[typeName]; allowed != nil {
+			filtered := make(map[string]any, len(allowed))
+			for k, val := range props {
+				if allowed[k] {
+					filtered[k] = val
+				}
+			}
+			props = filtered
 		}
 
 		propsJSON, err := json.Marshal(props)

--- a/core/type_schema.go
+++ b/core/type_schema.go
@@ -71,6 +71,15 @@ type Property struct {
 }
 
 
+// PropertyNames returns the set of property names defined in the schema.
+func (s *TypeSchema) PropertyNames() map[string]bool {
+	names := make(map[string]bool, len(s.Properties))
+	for _, p := range s.Properties {
+		names[p.Name] = true
+	}
+	return names
+}
+
 // defaultTypes contains built-in type schemas.
 var defaultTypes = map[string]TypeSchema{
 	"book": {

--- a/core/type_schema_test.go
+++ b/core/type_schema_test.go
@@ -773,4 +773,32 @@ func TestValidateObject_DateInvalidDate(t *testing.T) {
 	}
 }
 
+func TestTypeSchema_PropertyNames(t *testing.T) {
+	t.Run("empty schema", func(t *testing.T) {
+		schema := &TypeSchema{Name: "empty"}
+		names := schema.PropertyNames()
+		if len(names) != 0 {
+			t.Errorf("expected empty map, got %v", names)
+		}
+	})
 
+	t.Run("multi-property schema", func(t *testing.T) {
+		schema := &TypeSchema{
+			Name: "book",
+			Properties: []Property{
+				{Name: "title", Type: "string"},
+				{Name: "status", Type: "select"},
+				{Name: "rating", Type: "number"},
+			},
+		}
+		names := schema.PropertyNames()
+		if len(names) != 3 {
+			t.Fatalf("expected 3 names, got %d", len(names))
+		}
+		for _, name := range []string{"title", "status", "rating"} {
+			if !names[name] {
+				t.Errorf("expected %q in PropertyNames", name)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- SyncIndex now filters frontmatter properties by type schema, only indexing schema-defined keys into SQLite
- Undefined properties remain in markdown files on disk but are excluded from the index, queries, and display
- Added `PropertyNames()` helper on `TypeSchema` with per-type caching during sync
- 4 new BDD scenarios covering filtering, no-schema fallback, and frontmatter preservation

## Issue

Closes #174

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [x] Manual: create a book object with an undefined property (e.g. `mood: happy`), run `tmd sync`, verify `tmd object show` does not display `mood`