### PR TITLE
feat(cli): add tag name uniqueness check to `tmd type validate`

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -78,6 +78,17 @@ var validateCmd = &cobra.Command{
 			fmt.Println()
 		}
 
+		// Phase 5: Tag name uniqueness validation
+		tagErrs := core.ValidateTagNameUniqueness(vault)
+		if len(tagErrs) > 0 {
+			fmt.Println("Tag uniqueness errors:")
+			for _, e := range tagErrs {
+				fmt.Printf("  %s\n", e)
+				totalErrors++
+			}
+			fmt.Println()
+		}
+
 		if totalErrors > 0 {
 			return fmt.Errorf("found %d validation error(s)", totalErrors)
 		}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/typemd/typemd/core"
+)
+
+func TestValidateCmd_TagUniqueness(t *testing.T) {
+	dir := t.TempDir()
+	v := core.NewVault(dir)
+	if err := v.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := v.Open(); err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+
+	// Create one tag via normal API
+	if _, err := v.NewObject("tag", "go"); err != nil {
+		t.Fatalf("NewObject error = %v", err)
+	}
+
+	// Write a raw duplicate tag file on disk to bypass uniqueness check
+	dupeDir := filepath.Join(dir, "objects", "tag")
+	os.WriteFile(filepath.Join(dupeDir, "go-01jjjjjjjjjjjjjjjjjjjjjjjj.md"), []byte("---\nname: go\n---\n"), 0644)
+
+	v.Close()
+
+	// Run validate command with reindex to pick up the raw file
+	vaultPath = dir
+	reindex = true
+	defer func() { reindex = false }()
+	rootCmd.SetArgs([]string{"type", "validate"})
+	err := rootCmd.Execute()
+
+	if err == nil {
+		t.Fatal("expected validation error for duplicate tag names")
+	}
+	if !strings.Contains(err.Error(), "validation error") {
+		t.Errorf("error = %q, want it to mention validation error", err)
+	}
+
+}
+
+func TestValidateCmd_NoDuplicateTags(t *testing.T) {
+	dir := t.TempDir()
+	v := core.NewVault(dir)
+	if err := v.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	if err := v.Open(); err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+
+	v.NewObject("tag", "go")
+	v.NewObject("tag", "rust")
+	v.Close()
+
+	vaultPath = dir
+	rootCmd.SetArgs([]string{"type", "validate"})
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Errorf("expected no validation errors, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Wire `ValidateTagNameUniqueness` into `tmd type validate` as Phase 5, reporting duplicate tag names alongside existing schema, object, relation, and wiki-link checks
- Add CLI-level tests for both duplicate and non-duplicate tag scenarios

## Issue

Closes #215

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [x] Manual: create duplicate tag files on disk, run `tmd type validate --reindex`, confirm duplicate reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)