### PR TITLE
feat(core): add object templates for default content on creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,13 +18,14 @@ typemd is a local-first CLI knowledge management tool. Objects (books, people, i
 ## Data Model
 
 - Objects identified by `type/<slug>-<ulid>` (e.g. `book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz`)
-- All objects have system properties managed by typemd: `name` (auto-populated from slug, or from name template if defined), `description` (optional, user-authored), `created_at` (set on creation), `updated_at` (updated on save), `tags` (relation to built-in `tag` type, multiple). These appear first in frontmatter in that order.
+- All objects have system properties managed by typemd: `name` (auto-populated from slug, or from name template if defined), `description` (optional, user-authored), `created_at` (set on creation, immutable), `updated_at` (updated on save, immutable), `tags` (relation to built-in `tag` type, multiple). These appear first in frontmatter in that order. System properties are either **user-authored** (`name`, `description`, `tags` — can be overridden by templates) or **auto-managed** (`created_at`, `updated_at` — cannot be overridden).
 - Type schemas: `.typemd/types/*.yaml` (cannot define properties named `description`, `created_at`, `updated_at`, or `tags` — they're reserved system properties; `name` can appear in `properties` with only a `template` field for auto-generated names). Type schemas support optional `plural` (for display in collection contexts) and `unique` (to enforce name uniqueness) fields.
 - Shared properties: `.typemd/properties.yaml` (optional, defines reusable property definitions referenced via `use` in type schemas)
 - Relations defined as properties in type schemas
 - Wiki-links: `[[type/name-ulid]]` syntax in markdown body, with backlink tracking
 - SQLite index: `.typemd/index.db`
 - TUI session state: `.typemd/tui-state.yaml` (persisted on quit, restored on launch)
+- Object templates: `templates/<type>/<name>.md` (optional, Markdown files with frontmatter property overrides and body content applied during `tmd object create`; single template auto-applies, multiple templates prompt for selection or use `-t` flag)
 - Object files: `objects/<type>/<name>.md`
 
 ## Web UI Architecture

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ vault/
 │   ├── properties.yaml     # shared property definitions (optional)
 │   ├── index.db            # SQLite index (auto-updated)
 │   └── tui-state.yaml      # TUI session state (auto-saved)
+├── templates/              # object templates by type (optional)
+│   └── book/
+│       └── review.md       # template with default frontmatter + body
 └── objects/
     ├── book/
     │   └── golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz.md
@@ -91,6 +94,10 @@ tmd --readonly
 # Create a new object (ULID is appended automatically)
 tmd object create book clean-code
 # → Created book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz
+
+# Create with object template (auto-applied if only one exists)
+tmd object create book clean-code -t review
+# → Created book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz (with review template)
 
 # Create with name template (name auto-generated if type defines a template)
 tmd object create journal

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -44,6 +44,9 @@ vault/
 │   ├── properties.yaml     # 共用屬性定義（選用）
 │   ├── index.db            # SQLite 索引（自動更新）
 │   └── tui-state.yaml      # TUI 會話狀態（自動儲存）
+├── templates/              # 物件範本，依 Type 分類（選用）
+│   └── book/
+│       └── review.md       # 預設 frontmatter 和 body 內容
 └── objects/
     ├── book/
     │   └── golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz.md
@@ -88,6 +91,10 @@ tmd --vault /path/to/vault
 # 建立新的 Object（ULID 會自動附加）
 tmd object create book clean-code
 # → Created book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz
+
+# 建立 Object 時套用範本
+tmd object create book clean-code -t review
+# → Created book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz（套用 review 範本）
 
 # 顯示 Object 詳情（支援前綴匹配，不需要輸入完整 ULID）
 tmd object show book/clean-code

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,10 +1,16 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
+
+var templateFlag string
 
 var createCmd = &cobra.Command{
 	Use:   "create <type> [name]",
@@ -12,9 +18,11 @@ var createCmd = &cobra.Command{
 	Long: `Create a new object file (Markdown + YAML frontmatter) based on the type schema.
 A ULID is automatically appended to the filename for uniqueness.
 If the type has a name template, the name argument is optional.
+If the type has templates, they are applied automatically (single) or via selection (multiple).
 
 Examples:
   tmd object create book clean-code
+  tmd object create book clean-code -t review
   tmd object create person robert-martin
   tmd object create journal`,
 	Args: cobra.RangeArgs(1, 2),
@@ -25,11 +33,33 @@ Examples:
 		}
 		defer vault.Close()
 
+		typeName := args[0]
 		name := ""
 		if len(args) > 1 {
 			name = args[1]
 		}
-		obj, err := vault.NewObject(args[0], name)
+
+		// Resolve template
+		templateName := templateFlag
+		if templateName == "" {
+			templates, err := vault.ListTemplates(typeName)
+			if err != nil {
+				return err
+			}
+			switch len(templates) {
+			case 0:
+				// No templates, proceed without
+			case 1:
+				templateName = templates[0]
+			default:
+				templateName, err = promptTemplateSelection(templates)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		obj, err := vault.NewObject(typeName, name, templateName)
 		if err != nil {
 			return err
 		}
@@ -39,6 +69,26 @@ Examples:
 	},
 }
 
+func promptTemplateSelection(templates []string) (string, error) {
+	fmt.Println("Multiple templates available:")
+	for i, name := range templates {
+		fmt.Printf("  %d. %s\n", i+1, name)
+	}
+	fmt.Print("Select template (number): ")
+
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		return "", fmt.Errorf("no input received")
+	}
+	input := strings.TrimSpace(scanner.Text())
+	n, err := strconv.Atoi(input)
+	if err != nil || n < 1 || n > len(templates) {
+		return "", fmt.Errorf("invalid selection: %s", input)
+	}
+	return templates[n-1], nil
+}
+
 func init() {
+	createCmd.Flags().StringVarP(&templateFlag, "template", "t", "", "template name to use")
 	objectCmd.AddCommand(createCmd)
 }

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/typemd/typemd/core"
@@ -74,3 +75,77 @@ func TestCreateCmd_SameNameTwice(t *testing.T) {
 		t.Errorf("expected 2 matching files, got %d", len(matches))
 	}
 }
+
+func TestCreateCmd_WithTemplateFlag(t *testing.T) {
+	dir := setupTestVaultDir(t)
+
+	// Create a template
+	tmplDir := filepath.Join(dir, "templates", "book")
+	os.MkdirAll(tmplDir, 0755)
+	os.WriteFile(filepath.Join(tmplDir, "review.md"), []byte("---\ntitle: Review Template\n---\n\n## Review Notes\n"), 0644)
+
+	vaultPath = dir
+	templateFlag = "review"
+	defer func() { templateFlag = "" }()
+
+	rootCmd.SetArgs([]string{"object", "create", "book", "my-book", "-t", "review"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	matches, _ := filepath.Glob(filepath.Join(dir, "objects", "book", "my-book-*.md"))
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 matching file, got %d", len(matches))
+	}
+
+	data, _ := os.ReadFile(matches[0])
+	content := string(data)
+	if !strings.Contains(content, "Review Notes") {
+		t.Error("object should contain template body")
+	}
+	if !strings.Contains(content, "title: Review Template") {
+		t.Error("object should contain template property")
+	}
+}
+
+func TestCreateCmd_SingleTemplateAutoApply(t *testing.T) {
+	dir := setupTestVaultDir(t)
+
+	// Create a single template
+	tmplDir := filepath.Join(dir, "templates", "book")
+	os.MkdirAll(tmplDir, 0755)
+	os.WriteFile(filepath.Join(tmplDir, "default.md"), []byte("## Default Body\n"), 0644)
+
+	vaultPath = dir
+	templateFlag = ""
+
+	rootCmd.SetArgs([]string{"object", "create", "book", "auto-book"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	matches, _ := filepath.Glob(filepath.Join(dir, "objects", "book", "auto-book-*.md"))
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 matching file, got %d", len(matches))
+	}
+
+	data, _ := os.ReadFile(matches[0])
+	if !strings.Contains(string(data), "Default Body") {
+		t.Error("single template should be auto-applied")
+	}
+}
+
+func TestCreateCmd_InvalidTemplateFlag(t *testing.T) {
+	dir := setupTestVaultDir(t)
+
+	vaultPath = dir
+	templateFlag = "nonexistent"
+	defer func() { templateFlag = "" }()
+
+	rootCmd.SetArgs([]string{"object", "create", "book", "test-book", "-t", "nonexistent"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent template")
+	}
+}
+

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -20,7 +20,7 @@ func TestValidateCmd_TagUniqueness(t *testing.T) {
 	}
 
 	// Create one tag via normal API
-	if _, err := v.NewObject("tag", "go"); err != nil {
+	if _, err := v.NewObject("tag", "go", ""); err != nil {
 		t.Fatalf("NewObject error = %v", err)
 	}
 
@@ -56,8 +56,8 @@ func TestValidateCmd_NoDuplicateTags(t *testing.T) {
 		t.Fatalf("Open() error = %v", err)
 	}
 
-	v.NewObject("tag", "go")
-	v.NewObject("tag", "rust")
+	v.NewObject("tag", "go", "")
+	v.NewObject("tag", "rust", "")
 	v.Close()
 
 	vaultPath = dir

--- a/core/bdd_steps_common_test.go
+++ b/core/bdd_steps_common_test.go
@@ -52,6 +52,10 @@ type domainContext struct {
 
 	// name uniqueness validation results
 	nameUniquenessErrors []error
+
+	// template results
+	templateNames  []string
+	loadedTemplate *Template
 }
 
 func newDomainContext() *domainContext {

--- a/core/bdd_steps_name_template_test.go
+++ b/core/bdd_steps_name_template_test.go
@@ -15,7 +15,7 @@ func (dc *domainContext) aTypeSchemaWithNameTemplate(typeName, template string) 
 }
 
 func (dc *domainContext) iCreateAObjectWithNoName(typeName string) {
-	obj, err := dc.vault.NewObject(typeName, "")
+	obj, err := dc.vault.NewObject(typeName, "", "")
 	dc.lastErr = err
 	if err == nil {
 		dc.currentObject = obj

--- a/core/bdd_steps_object_test.go
+++ b/core/bdd_steps_object_test.go
@@ -63,7 +63,7 @@ properties:
 }
 
 func (dc *domainContext) iCreateAObjectNamed(typeName, name string) {
-	obj, err := dc.vault.NewObject(typeName, name)
+	obj, err := dc.vault.NewObject(typeName, name, "")
 	dc.lastErr = err
 	if err == nil {
 		dc.objects[name] = obj
@@ -73,7 +73,7 @@ func (dc *domainContext) iCreateAObjectNamed(typeName, name string) {
 
 func (dc *domainContext) iCreateAnotherObjectNamed(typeName, name string) {
 	dc.prevObject = dc.currentObject
-	obj, err := dc.vault.NewObject(typeName, name)
+	obj, err := dc.vault.NewObject(typeName, name, "")
 	dc.lastErr = err
 	if err == nil {
 		dc.objects[name+"_2"] = obj
@@ -139,7 +139,7 @@ func (dc *domainContext) theTwoObjectsShouldHaveDifferentIDs() error {
 }
 
 func (dc *domainContext) aObjectNamedExists(typeName, name string) {
-	obj, err := dc.vault.NewObject(typeName, name)
+	obj, err := dc.vault.NewObject(typeName, name, "")
 	if err != nil {
 		panic(fmt.Sprintf("create object %s/%s failed: %v", typeName, name, err))
 	}

--- a/core/bdd_steps_system_test.go
+++ b/core/bdd_steps_system_test.go
@@ -209,6 +209,20 @@ func (dc *domainContext) theFrontmatterShouldHaveBefore(first, second string) er
 	return nil
 }
 
+func (dc *domainContext) shouldBeAnImmutableSystemProperty(name string) error {
+	if !IsImmutableSystemProperty(name) {
+		return fmt.Errorf("%q should be an immutable system property", name)
+	}
+	return nil
+}
+
+func (dc *domainContext) shouldNotBeAnImmutableSystemProperty(name string) error {
+	if IsImmutableSystemProperty(name) {
+		return fmt.Errorf("%q should not be an immutable system property", name)
+	}
+	return nil
+}
+
 func initSystemSteps(ctx *godog.ScenarioContext, dc *domainContext) {
 	ctx.Step(`^the system property registry should contain "([^"]*)"$`, dc.theSystemPropertyRegistryShouldContain)
 	ctx.Step(`^"([^"]*)" should be a system property$`, dc.shouldBeASystemProperty)
@@ -226,4 +240,6 @@ func initSystemSteps(ctx *godog.ScenarioContext, dc *domainContext) {
 	ctx.Step(`^a raw object file with description exists$`, dc.aRawObjectFileWithDescriptionExists)
 	ctx.Step(`^the raw object file should not have description added$`, dc.theRawObjectFileShouldNotHaveDescriptionAdded)
 	ctx.Step(`^the frontmatter should have "([^"]*)" before "([^"]*)"$`, dc.theFrontmatterShouldHaveBefore)
+	ctx.Step(`^"([^"]*)" should be an immutable system property$`, dc.shouldBeAnImmutableSystemProperty)
+	ctx.Step(`^"([^"]*)" should not be an immutable system property$`, dc.shouldNotBeAnImmutableSystemProperty)
 }

--- a/core/bdd_steps_tag_test.go
+++ b/core/bdd_steps_tag_test.go
@@ -21,7 +21,7 @@ func (dc *domainContext) theObjectShouldHavePropertyWithNilValue(propName string
 }
 
 func (dc *domainContext) iSetTagsOnTheObjectToATagReference() {
-	tagObj, err := dc.vault.NewObject("tag", "test-tag")
+	tagObj, err := dc.vault.NewObject("tag", "test-tag", "")
 	if err != nil {
 		panic(fmt.Sprintf("create tag object failed: %v", err))
 	}
@@ -40,7 +40,7 @@ func (dc *domainContext) aRawDuplicateTagNamedExists(name string) {
 // ── Tag resolution steps ────────────────────────────────────────────────
 
 func (dc *domainContext) aBookObjectExistsWithTagReferenceByID(bookName string) {
-	book, err := dc.vault.NewObject("book", bookName)
+	book, err := dc.vault.NewObject("book", bookName, "")
 	if err != nil {
 		panic(fmt.Sprintf("create book: %v", err))
 	}
@@ -58,7 +58,7 @@ func (dc *domainContext) aBookObjectExistsWithTagReferenceByID(bookName string) 
 }
 
 func (dc *domainContext) aBookObjectExistsWithTagReferenceByName(bookName, tagName string) {
-	book, err := dc.vault.NewObject("book", bookName)
+	book, err := dc.vault.NewObject("book", bookName, "")
 	if err != nil {
 		panic(fmt.Sprintf("create book: %v", err))
 	}

--- a/core/bdd_steps_template_test.go
+++ b/core/bdd_steps_template_test.go
@@ -1,0 +1,154 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cucumber/godog"
+)
+
+// ── Template steps ───────────────────────────────────────────────────────────
+
+func (dc *domainContext) writeTemplateFile(typeName, templateName, content string) {
+	os.MkdirAll(dc.vault.TypeTemplatesDir(typeName), 0755)
+	path := dc.vault.TemplatePath(typeName, templateName)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		panic(fmt.Sprintf("write template: %v", err))
+	}
+}
+
+func (dc *domainContext) aTemplateForTypeWithBody(templateName, typeName, body string) {
+	dc.writeTemplateFile(typeName, templateName, body+"\n")
+}
+
+func (dc *domainContext) aTemplateForTypeWithFrontmatterAndBody(templateName, typeName, frontmatter, body string) {
+	var content string
+	if frontmatter != "" && body != "" {
+		content = fmt.Sprintf("---\n%s\n---\n\n%s\n", frontmatter, body)
+	} else if frontmatter != "" {
+		content = fmt.Sprintf("---\n%s\n---\n", frontmatter)
+	} else {
+		content = body + "\n"
+	}
+	dc.writeTemplateFile(typeName, templateName, content)
+}
+
+func (dc *domainContext) anEmptyTemplatesDirectoryForType(typeName string) {
+	dir := dc.vault.TypeTemplatesDir(typeName)
+	os.MkdirAll(dir, 0755)
+}
+
+func (dc *domainContext) iListTemplatesForType(typeName string) {
+	names, err := dc.vault.ListTemplates(typeName)
+	dc.lastErr = err
+	if err == nil {
+		dc.templateNames = names
+	}
+}
+
+func (dc *domainContext) theTemplateListShouldContain(expected string) error {
+	expectedNames := strings.Split(expected, ", ")
+	if len(dc.templateNames) != len(expectedNames) {
+		return fmt.Errorf("template list has %d items, want %d: %v", len(dc.templateNames), len(expectedNames), dc.templateNames)
+	}
+	for _, name := range expectedNames {
+		found := false
+		for _, got := range dc.templateNames {
+			if got == strings.TrimSpace(name) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("template list missing %q: %v", name, dc.templateNames)
+		}
+	}
+	return nil
+}
+
+func (dc *domainContext) theTemplateListShouldBeEmpty() error {
+	if len(dc.templateNames) != 0 {
+		return fmt.Errorf("expected empty template list, got %v", dc.templateNames)
+	}
+	return nil
+}
+
+func (dc *domainContext) iLoadTemplateForType(templateName, typeName string) {
+	tmpl, err := dc.vault.LoadTemplate(typeName, templateName)
+	dc.lastErr = err
+	dc.loadedTemplate = tmpl
+}
+
+func (dc *domainContext) theTemplatePropertyShouldBe(key, expected string) error {
+	if dc.loadedTemplate == nil {
+		return fmt.Errorf("no template loaded")
+	}
+	val := fmt.Sprintf("%v", dc.loadedTemplate.Properties[key])
+	if val != expected {
+		return fmt.Errorf("template property %q = %q, want %q", key, val, expected)
+	}
+	return nil
+}
+
+func (dc *domainContext) theTemplateBodyShouldBe(expected string) error {
+	if dc.loadedTemplate == nil {
+		return fmt.Errorf("no template loaded")
+	}
+	body := strings.TrimRight(dc.loadedTemplate.Body, "\n")
+	if body != expected {
+		return fmt.Errorf("template body = %q, want %q", body, expected)
+	}
+	return nil
+}
+
+func (dc *domainContext) theTemplateLoadShouldFail() error {
+	if dc.lastErr == nil {
+		return fmt.Errorf("expected template load to fail, got nil error")
+	}
+	return nil
+}
+
+func (dc *domainContext) iCreateAObjectNamedWithTemplate(typeName, name, templateName string) {
+	obj, err := dc.vault.NewObject(typeName, name, templateName)
+	dc.lastErr = err
+	if err == nil {
+		dc.objects[name] = obj
+		dc.currentObject = obj
+	}
+}
+
+func (dc *domainContext) theObjectBodyShouldBe(expected string) error {
+	got, err := dc.vault.GetObject(dc.currentObject.ID)
+	if err != nil {
+		return fmt.Errorf("GetObject error: %v", err)
+	}
+	body := strings.TrimRight(got.Body, "\n")
+	if body != expected {
+		return fmt.Errorf("object body = %q, want %q", body, expected)
+	}
+	return nil
+}
+
+func (dc *domainContext) theObjectCreationShouldFail() error {
+	if dc.lastErr == nil {
+		return fmt.Errorf("expected object creation to fail, got nil error")
+	}
+	return nil
+}
+
+func initTemplateSteps(ctx *godog.ScenarioContext, dc *domainContext) {
+	ctx.Step(`^a template "([^"]*)" for type "([^"]*)" with body "([^"]*)"$`, dc.aTemplateForTypeWithBody)
+	ctx.Step(`^a template "([^"]*)" for type "([^"]*)" with frontmatter "([^"]*)" and body "([^"]*)"$`, dc.aTemplateForTypeWithFrontmatterAndBody)
+	ctx.Step(`^an empty templates directory for type "([^"]*)"$`, dc.anEmptyTemplatesDirectoryForType)
+	ctx.Step(`^I list templates for type "([^"]*)"$`, dc.iListTemplatesForType)
+	ctx.Step(`^the template list should contain "([^"]*)"$`, dc.theTemplateListShouldContain)
+	ctx.Step(`^the template list should be empty$`, dc.theTemplateListShouldBeEmpty)
+	ctx.Step(`^I load template "([^"]*)" for type "([^"]*)"$`, dc.iLoadTemplateForType)
+	ctx.Step(`^the template property "([^"]*)" should be "([^"]*)"$`, dc.theTemplatePropertyShouldBe)
+	ctx.Step(`^the template body should be "([^"]*)"$`, dc.theTemplateBodyShouldBe)
+	ctx.Step(`^the template load should fail$`, dc.theTemplateLoadShouldFail)
+	ctx.Step(`^I create a "([^"]*)" object named "([^"]*)" with template "([^"]*)"$`, dc.iCreateAObjectNamedWithTemplate)
+	ctx.Step(`^the object body should be "([^"]*)"$`, dc.theObjectBodyShouldBe)
+	ctx.Step(`^the object creation should fail$`, dc.theObjectCreationShouldFail)
+}

--- a/core/bdd_steps_validate_test.go
+++ b/core/bdd_steps_validate_test.go
@@ -62,8 +62,8 @@ func (dc *domainContext) twoLinkedNotesExist() {
 	os.WriteFile(filepath.Join(dc.vault.TypesDir(), "note.yaml"),
 		[]byte("name: note\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
-	noteA, _ := dc.vault.NewObject("note", "alpha")
-	noteB, _ := dc.vault.NewObject("note", "beta")
+	noteA, _ := dc.vault.NewObject("note", "alpha", "")
+	noteB, _ := dc.vault.NewObject("note", "beta", "")
 	dc.objects["alpha"] = noteA
 	dc.objects["beta"] = noteB
 
@@ -76,7 +76,7 @@ func (dc *domainContext) aNoteWithABrokenWikiLinkExists() {
 	os.WriteFile(filepath.Join(dc.vault.TypesDir(), "note.yaml"),
 		[]byte("name: note\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
-	note, _ := dc.vault.NewObject("note", "alpha")
+	note, _ := dc.vault.NewObject("note", "alpha", "")
 	dc.objects["alpha"] = note
 
 	body := "---\ntitle: Alpha\n---\n\nSee [[note/nonexistent-01jjjjjjjjjjjjjjjjjjjjjjjj]].\n"

--- a/core/bdd_test.go
+++ b/core/bdd_test.go
@@ -148,6 +148,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	initPluralSteps(ctx, dc)
 	initNameTemplateSteps(ctx, dc)
 	initUniqueSteps(ctx, dc)
+	initTemplateSteps(ctx, dc)
 }
 
 func TestFeatures(t *testing.T) {

--- a/core/display_test.go
+++ b/core/display_test.go
@@ -20,7 +20,7 @@ func TestBuildDisplayProperties(t *testing.T) {
 	defer v.Close()
 
 	// Create two objects and link them
-	book, err := v.NewObject("book", "test-book")
+	book, err := v.NewObject("book", "test-book", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,11 +79,11 @@ properties:
 	}
 	defer v.Close()
 
-	article, err := v.NewObject("article", "test-article")
+	article, err := v.NewObject("article", "test-article", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	person, err := v.NewObject("person", "test-person")
+	person, err := v.NewObject("person", "test-person", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,8 +137,8 @@ func TestBuildDisplayPropertiesWithBacklinks(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "note.yaml"),
 		[]byte("name: note\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
-	noteA, _ := v.NewObject("note", "alpha")
-	noteB, _ := v.NewObject("note", "beta")
+	noteA, _ := v.NewObject("note", "alpha", "")
+	noteB, _ := v.NewObject("note", "beta", "")
 
 	// noteA links to noteB via wiki-link
 	bodyA := fmt.Sprintf("---\ntitle: Alpha\n---\n\nSee [[%s]].\n", noteB.ID)
@@ -175,7 +175,7 @@ func TestBuildDisplayPropertiesNoBacklinks(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "note.yaml"),
 		[]byte("name: note\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
-	note, _ := v.NewObject("note", "lonely")
+	note, _ := v.NewObject("note", "lonely", "")
 
 	props, err := v.BuildDisplayProperties(note)
 	if err != nil {

--- a/core/features/object_template.feature
+++ b/core/features/object_template.feature
@@ -1,0 +1,92 @@
+Feature: Object templates
+  Types can define templates that provide default frontmatter and body content
+  when creating new objects.
+
+  Scenario: List templates for type with multiple templates
+    Given a vault is ready
+    And a template "review" for type "book" with body "## Review"
+    And a template "summary" for type "book" with body "## Summary"
+    When I list templates for type "book"
+    Then the template list should contain "review, summary"
+
+  Scenario: List templates for type with one template
+    Given a vault is ready
+    And a template "default" for type "book" with body "## Notes"
+    When I list templates for type "book"
+    Then the template list should contain "default"
+
+  Scenario: List templates for type with no templates directory
+    Given a vault is ready
+    When I list templates for type "book"
+    Then the template list should be empty
+
+  Scenario: List templates for type with empty templates directory
+    Given a vault is ready
+    And an empty templates directory for type "book"
+    When I list templates for type "book"
+    Then the template list should be empty
+
+  Scenario: Load template with frontmatter and body
+    Given a vault is ready
+    And a template "review" for type "book" with frontmatter "status: draft" and body "## Notes"
+    When I load template "review" for type "book"
+    Then the template property "status" should be "draft"
+    And the template body should be "## Notes"
+
+  Scenario: Load template with body only
+    Given a vault is ready
+    And a template "simple" for type "book" with body "## My Book"
+    When I load template "simple" for type "book"
+    Then the template body should be "## My Book"
+
+  Scenario: Load template with frontmatter only
+    Given a vault is ready
+    And a template "preset" for type "book" with frontmatter "status: reading" and body ""
+    When I load template "preset" for type "book"
+    Then the template property "status" should be "reading"
+
+  Scenario: Load nonexistent template returns error
+    Given a vault is ready
+    When I load template "nonexistent" for type "book"
+    Then the template load should fail
+
+  Scenario: Create object with template body and properties
+    Given a vault is ready
+    And a template "review" for type "book" with frontmatter "status: draft" and body "## Review Notes"
+    When I create a "book" object named "my-book" with template "review"
+    Then the object property "status" should be "draft"
+    And the object body should be "## Review Notes"
+
+  Scenario: Template overrides schema default
+    Given a vault is ready
+    And a template "review" for type "book" with frontmatter "status: draft" and body ""
+    When I create a "book" object named "my-book" with template "review"
+    Then the object property "status" should be "draft"
+
+  Scenario: Create object without template preserves current behavior
+    Given a vault is ready
+    When I create a "book" object named "my-book"
+    Then the object body should be ""
+
+  Scenario: Template with mutable system property description
+    Given a vault is ready
+    And a template "review" for type "book" with frontmatter "description: A book review" and body ""
+    When I create a "book" object named "my-book" with template "review"
+    Then the object property "description" should be "A book review"
+
+  Scenario: Template with immutable system property created_at is ignored
+    Given a vault is ready
+    And a template "review" for type "book" with frontmatter "created_at: 2020-01-01T00:00:00Z" and body ""
+    When I create a "book" object named "my-book" with template "review"
+    Then the object "created_at" should be recent
+
+  Scenario: Template with unknown property is ignored
+    Given a vault is ready
+    And a template "review" for type "book" with frontmatter "unknown_prop: value" and body ""
+    When I create a "book" object named "my-book" with template "review"
+    Then the object should not have property "unknown_prop"
+
+  Scenario: Nonexistent template name in create returns error
+    Given a vault is ready
+    When I create a "book" object named "my-book" with template "nonexistent"
+    Then the object creation should fail

--- a/core/features/system_property.feature
+++ b/core/features/system_property.feature
@@ -128,3 +128,15 @@ Feature: System property registry
     And a shared properties file with a system property "tags"
     When I validate all schemas
     Then shared properties should have errors
+
+  Scenario: Immutable system properties are identified
+    Then "created_at" should be an immutable system property
+    And "updated_at" should be an immutable system property
+
+  Scenario: Mutable system properties are not immutable
+    Then "name" should not be an immutable system property
+    And "description" should not be an immutable system property
+    And "tags" should not be an immutable system property
+
+  Scenario: Non-system properties are not immutable
+    Then "title" should not be an immutable system property

--- a/core/migrate_test.go
+++ b/core/migrate_test.go
@@ -27,8 +27,8 @@ func TestVault_MigrateObjects_AddProperty(t *testing.T) {
 	v := setupMigrateTestVault(t)
 
 	// Create objects with original schema
-	objA, _ := v.NewObject("book", "book-a")
-	objB, _ := v.NewObject("book", "book-b")
+	objA, _ := v.NewObject("book", "book-a", "")
+	objB, _ := v.NewObject("book", "book-b", "")
 
 	// Update schema: add isbn with default
 	newSchema := []byte(`name: book
@@ -67,7 +67,7 @@ properties:
 func TestVault_MigrateObjects_RemoveProperty(t *testing.T) {
 	v := setupMigrateTestVault(t)
 
-	created, _ := v.NewObject("book", "test")
+	created, _ := v.NewObject("book", "test", "")
 
 	// Update schema: remove status
 	newSchema := []byte(`name: book
@@ -98,7 +98,7 @@ properties:
 func TestVault_MigrateObjects_RenameProperty(t *testing.T) {
 	v := setupMigrateTestVault(t)
 
-	created, _ := v.NewObject("book", "test")
+	created, _ := v.NewObject("book", "test", "")
 	v.SetProperty(created.ID, "status", "reading")
 
 	// Update schema: rename status -> reading_status
@@ -137,7 +137,7 @@ properties:
 func TestVault_MigrateObjects_DryRun(t *testing.T) {
 	v := setupMigrateTestVault(t)
 
-	created, _ := v.NewObject("book", "test")
+	created, _ := v.NewObject("book", "test", "")
 
 	// Update schema: add isbn
 	newSchema := []byte(`name: book
@@ -171,7 +171,7 @@ properties:
 func TestVault_MigrateObjects_NoChanges(t *testing.T) {
 	v := setupMigrateTestVault(t)
 
-	v.NewObject("book", "test")
+	v.NewObject("book", "test", "")
 
 	// Schema unchanged — no migration needed
 	result, err := v.MigrateObjects("book", MigrateOptions{})

--- a/core/object.go
+++ b/core/object.go
@@ -121,7 +121,8 @@ func parseFrontmatter(data []byte) (map[string]any, string, error) {
 }
 
 // NewObject creates a new object with the given type and filename.
-func (v *Vault) NewObject(typeName, filename string) (*Object, error) {
+// If templateName is non-empty, the specified template is loaded and applied.
+func (v *Vault) NewObject(typeName, filename, templateName string) (*Object, error) {
 	if v.db == nil {
 		return nil, fmt.Errorf("vault not opened")
 	}
@@ -131,14 +132,32 @@ func (v *Vault) NewObject(typeName, filename string) (*Object, error) {
 		return nil, fmt.Errorf("load type: %w", err)
 	}
 
+	// Load template if specified
+	var tmpl *Template
+	if templateName != "" {
+		tmpl, err = v.LoadTemplate(typeName, templateName)
+		if err != nil {
+			return nil, fmt.Errorf("load template: %w", err)
+		}
+	}
+
 	now := time.Now()
 
-	// Handle empty name: use template or error
+	// Handle empty name: check template, then name template, then error
 	if filename == "" {
-		if schema.NameTemplate != "" {
-			filename = EvaluateNameTemplate(schema.NameTemplate, now)
-		} else {
-			return nil, fmt.Errorf("name is required (type %q has no name template)", typeName)
+		if tmpl != nil {
+			if nameVal, ok := tmpl.Properties[NameProperty]; ok {
+				if s, ok := nameVal.(string); ok && s != "" {
+					filename = s
+				}
+			}
+		}
+		if filename == "" {
+			if schema.NameTemplate != "" {
+				filename = EvaluateNameTemplate(schema.NameTemplate, now)
+			} else {
+				return nil, fmt.Errorf("name is required (type %q has no name template)", typeName)
+			}
 		}
 	}
 
@@ -164,9 +183,9 @@ func (v *Vault) NewObject(typeName, filename string) (*Object, error) {
 		return nil, fmt.Errorf("create directory: %w", err)
 	}
 
-	// Generate initial properties from schema
+	// Generate initial properties from schema defaults
 	props := make(map[string]any)
-	props[NameProperty] = slug // system property: display name from slug
+	props[NameProperty] = slug
 	nowStr := now.Format(time.RFC3339)
 	props[CreatedAtProperty] = nowStr
 	props[UpdatedAtProperty] = nowStr
@@ -178,8 +197,18 @@ func (v *Vault) NewObject(typeName, filename string) (*Object, error) {
 		}
 	}
 
+	// Apply template properties (overrides schema defaults)
+	body := ""
+	if tmpl != nil {
+		filtered := filterTemplateProperties(tmpl.Properties, schema)
+		for key, val := range filtered {
+			props[key] = val
+		}
+		body = tmpl.Body
+	}
+
 	// Write .md file (O_EXCL ensures atomic uniqueness check)
-	data, err := writeFrontmatter(props, "", OrderedPropKeys(props, schema))
+	data, err := writeFrontmatter(props, body, OrderedPropKeys(props, schema))
 	if err != nil {
 		return nil, fmt.Errorf("write frontmatter: %w", err)
 	}
@@ -205,7 +234,7 @@ func (v *Vault) NewObject(typeName, filename string) (*Object, error) {
 	}
 	_, err = v.db.Exec(
 		"INSERT INTO objects (id, type, filename, properties, body) VALUES (?, ?, ?, ?, ?)",
-		id, typeName, filename, string(propsJSON), "",
+		id, typeName, filename, string(propsJSON), body,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert object: %w", err)
@@ -216,7 +245,7 @@ func (v *Vault) NewObject(typeName, filename string) (*Object, error) {
 		Type:       typeName,
 		Filename:   filename,
 		Properties: props,
-		Body:       "",
+		Body:       body,
 	}, nil
 }
 

--- a/core/object_test.go
+++ b/core/object_test.go
@@ -217,7 +217,7 @@ func TestObject_GetName(t *testing.T) {
 func TestVault_NewObject(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "golang-in-action")
+	obj, err := v.NewObject("book", "golang-in-action", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -254,12 +254,12 @@ func TestVault_NewObject(t *testing.T) {
 func TestVault_NewObject_SameNameDifferentULID(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj1, err := v.NewObject("book", "test")
+	obj1, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("first NewObject() error = %v", err)
 	}
 
-	obj2, err := v.NewObject("book", "test")
+	obj2, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("second NewObject() should succeed with ULID, error = %v", err)
 	}
@@ -275,7 +275,7 @@ func TestVault_NewObject_SameNameDifferentULID(t *testing.T) {
 func TestVault_NewObject_UnknownType(t *testing.T) {
 	v := setupTestVault(t)
 
-	_, err := v.NewObject("nonexistent", "test")
+	_, err := v.NewObject("nonexistent", "test", "")
 	if err == nil {
 		t.Fatal("expected error for unknown type, got nil")
 	}
@@ -289,7 +289,7 @@ func TestVault_NewObject_DBNotOpen(t *testing.T) {
 	}
 	// 不呼叫 Open()
 
-	_, err := v.NewObject("book", "test")
+	_, err := v.NewObject("book", "test", "")
 	if err == nil {
 		t.Fatal("expected error when DB not opened, got nil")
 	}
@@ -312,7 +312,7 @@ properties:
 		t.Fatalf("WriteFile error = %v", err)
 	}
 
-	obj, err := v.NewObject("task", "my-task")
+	obj, err := v.NewObject("task", "my-task", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -336,7 +336,7 @@ properties:
 func TestVault_GetObject(t *testing.T) {
 	v := setupTestVault(t)
 
-	created, err := v.NewObject("book", "golang-in-action")
+	created, err := v.NewObject("book", "golang-in-action", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -378,7 +378,7 @@ func TestVault_GetObject_InvalidID(t *testing.T) {
 func TestVault_SetProperty(t *testing.T) {
 	v := setupTestVault(t)
 
-	created, err := v.NewObject("book", "test")
+	created, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -400,7 +400,7 @@ func TestVault_SetProperty(t *testing.T) {
 func TestVault_SetProperty_ValidationError(t *testing.T) {
 	v := setupTestVault(t)
 
-	created, err := v.NewObject("book", "test")
+	created, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -415,7 +415,7 @@ func TestVault_SetProperty_ValidationError(t *testing.T) {
 func TestVault_SetProperty_ExtraKey(t *testing.T) {
 	v := setupTestVault(t)
 
-	created, err := v.NewObject("book", "test")
+	created, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -459,7 +459,7 @@ func TestVault_SetProperty_DBNotOpen(t *testing.T) {
 
 func TestVault_SaveObject_WritesFileAndUpdatesDB(t *testing.T) {
 	v := setupTestVault(t)
-	obj, err := v.NewObject("book", "test-book")
+	obj, err := v.NewObject("book", "test-book", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -540,7 +540,7 @@ func TestVault_ResolveID_TypeDirNotExist(t *testing.T) {
 func TestVault_ResolveID_ExactMatch(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "test-resolve")
+	obj, err := v.NewObject("book", "test-resolve", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -557,7 +557,7 @@ func TestVault_ResolveID_ExactMatch(t *testing.T) {
 func TestVault_ResolveID_PrefixMatch(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "unique-prefix")
+	obj, err := v.NewObject("book", "unique-prefix", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -574,11 +574,11 @@ func TestVault_ResolveID_PrefixMatch(t *testing.T) {
 func TestVault_ResolveID_AmbiguousMatch(t *testing.T) {
 	v := setupTestVault(t)
 
-	_, err := v.NewObject("book", "ambig")
+	_, err := v.NewObject("book", "ambig", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
-	_, err = v.NewObject("book", "ambig")
+	_, err = v.NewObject("book", "ambig", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -599,7 +599,7 @@ func TestVault_ResolveID_AmbiguousMatch(t *testing.T) {
 func TestVault_ResolveObject(t *testing.T) {
 	v := setupTestVault(t)
 
-	created, err := v.NewObject("book", "resolve-obj")
+	created, err := v.NewObject("book", "resolve-obj", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}

--- a/core/query_test.go
+++ b/core/query_test.go
@@ -88,9 +88,9 @@ func TestParseFilter_ValueWithEquals(t *testing.T) {
 func TestVault_QueryObjects_ByType(t *testing.T) {
 	v := setupTestVault(t)
 
-	v.NewObject("book", "book1")   //nolint:errcheck
-	v.NewObject("book", "book2")   //nolint:errcheck
-	v.NewObject("person", "alice") //nolint:errcheck
+	v.NewObject("book", "book1", "")   //nolint:errcheck
+	v.NewObject("book", "book2", "")   //nolint:errcheck
+	v.NewObject("person", "alice", "") //nolint:errcheck
 
 	results, err := v.QueryObjects("type=book")
 	if err != nil {
@@ -109,10 +109,10 @@ func TestVault_QueryObjects_ByType(t *testing.T) {
 func TestVault_QueryObjects_ByProperty(t *testing.T) {
 	v := setupTestVault(t)
 
-	b1, _ := v.NewObject("book", "book1")
+	b1, _ := v.NewObject("book", "book1", "")
 	v.SetProperty(b1.ID, "status", "reading") //nolint:errcheck
 
-	b2, _ := v.NewObject("book", "book2")
+	b2, _ := v.NewObject("book", "book2", "")
 	v.SetProperty(b2.ID, "status", "done") //nolint:errcheck
 
 	results, err := v.QueryObjects("type=book status=reading")
@@ -130,7 +130,7 @@ func TestVault_QueryObjects_ByProperty(t *testing.T) {
 func TestVault_QueryObjects_NoResults(t *testing.T) {
 	v := setupTestVault(t)
 
-	v.NewObject("book", "book1") //nolint:errcheck
+	v.NewObject("book", "book1", "") //nolint:errcheck
 
 	results, err := v.QueryObjects("type=person")
 	if err != nil {
@@ -144,8 +144,8 @@ func TestVault_QueryObjects_NoResults(t *testing.T) {
 func TestVault_QueryObjects_EmptyFilter(t *testing.T) {
 	v := setupTestVault(t)
 
-	v.NewObject("book", "book1")   //nolint:errcheck
-	v.NewObject("person", "alice") //nolint:errcheck
+	v.NewObject("book", "book1", "")   //nolint:errcheck
+	v.NewObject("person", "alice", "") //nolint:errcheck
 
 	results, err := v.QueryObjects("")
 	if err != nil {
@@ -181,15 +181,15 @@ func TestVault_QueryObjects_DBNotOpen(t *testing.T) {
 func TestVault_QueryObjects_MultipleConditions(t *testing.T) {
 	v := setupTestVault(t)
 
-	b1, _ := v.NewObject("book", "b1")
+	b1, _ := v.NewObject("book", "b1", "")
 	v.SetProperty(b1.ID, "status", "reading") //nolint:errcheck
 	v.SetProperty(b1.ID, "title", "Go")       //nolint:errcheck
 
-	b2, _ := v.NewObject("book", "b2")
+	b2, _ := v.NewObject("book", "b2", "")
 	v.SetProperty(b2.ID, "status", "reading") //nolint:errcheck
 	v.SetProperty(b2.ID, "title", "Rust")     //nolint:errcheck
 
-	b3, _ := v.NewObject("book", "b3")
+	b3, _ := v.NewObject("book", "b3", "")
 	v.SetProperty(b3.ID, "status", "done") //nolint:errcheck
 	v.SetProperty(b3.ID, "title", "Go")    //nolint:errcheck
 
@@ -211,8 +211,8 @@ func TestVault_QueryObjects_MultipleConditions(t *testing.T) {
 func TestVault_SearchObjects_ByFilename(t *testing.T) {
 	v := setupTestVault(t)
 
-	concurrency, _ := v.NewObject("book", "concurrency-in-go")
-	v.NewObject("book", "clean-code") //nolint:errcheck
+	concurrency, _ := v.NewObject("book", "concurrency-in-go", "")
+	v.NewObject("book", "clean-code", "") //nolint:errcheck
 
 	results, err := v.SearchObjects("concurrency")
 	if err != nil {
@@ -229,7 +229,7 @@ func TestVault_SearchObjects_ByFilename(t *testing.T) {
 func TestVault_SearchObjects_ByBody(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "mybook")
+	obj, err := v.NewObject("book", "mybook", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -238,7 +238,7 @@ func TestVault_SearchObjects_ByBody(t *testing.T) {
 		t.Fatalf("saveObjectFile() error = %v", err)
 	}
 
-	v.NewObject("book", "other") //nolint:errcheck
+	v.NewObject("book", "other", "") //nolint:errcheck
 
 	results, err := v.SearchObjects("goroutines")
 	if err != nil {
@@ -255,10 +255,10 @@ func TestVault_SearchObjects_ByBody(t *testing.T) {
 func TestVault_SearchObjects_ByProperty(t *testing.T) {
 	v := setupTestVault(t)
 
-	b1, _ := v.NewObject("book", "book1")
+	b1, _ := v.NewObject("book", "book1", "")
 	v.SetProperty(b1.ID, "title", "Mastering Go") //nolint:errcheck
 
-	b2, _ := v.NewObject("book", "book2")
+	b2, _ := v.NewObject("book", "book2", "")
 	v.SetProperty(b2.ID, "title", "Python Basics") //nolint:errcheck
 
 	results, err := v.SearchObjects("Mastering")
@@ -276,7 +276,7 @@ func TestVault_SearchObjects_ByProperty(t *testing.T) {
 func TestVault_SearchObjects_NoResults(t *testing.T) {
 	v := setupTestVault(t)
 
-	v.NewObject("book", "testbook") //nolint:errcheck
+	v.NewObject("book", "testbook", "") //nolint:errcheck
 
 	results, err := v.SearchObjects("xyzzy")
 	if err != nil {
@@ -290,7 +290,7 @@ func TestVault_SearchObjects_NoResults(t *testing.T) {
 func TestVault_SearchObjects_EmptyKeyword(t *testing.T) {
 	v := setupTestVault(t)
 
-	v.NewObject("book", "book1") //nolint:errcheck
+	v.NewObject("book", "book1", "") //nolint:errcheck
 
 	results, err := v.SearchObjects("")
 	if err != nil {
@@ -317,7 +317,7 @@ func TestVault_SearchObjects_DBNotOpen(t *testing.T) {
 func TestVault_SearchObjects_UpdateSync(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "evolving")
+	obj, err := v.NewObject("book", "evolving", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -348,7 +348,7 @@ func TestVault_SearchObjects_UpdateSync(t *testing.T) {
 func TestVault_RebuildIndex(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "golang-in-action")
+	obj, err := v.NewObject("book", "golang-in-action", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}

--- a/core/relation_list_test.go
+++ b/core/relation_list_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestVault_ListRelations_Empty(t *testing.T) {
 	v := setupRelationTestVault(t)
-	book, _ := v.NewObject("book", "test")
+	book, _ := v.NewObject("book", "test", "")
 
 	rels, err := v.ListRelations(book.ID)
 	if err != nil {
@@ -17,8 +17,8 @@ func TestVault_ListRelations_Empty(t *testing.T) {
 
 func TestVault_ListRelations_Forward(t *testing.T) {
 	v := setupRelationTestVault(t)
-	book, _ := v.NewObject("book", "test")
-	alan, _ := v.NewObject("person", "alan")
+	book, _ := v.NewObject("book", "test", "")
+	alan, _ := v.NewObject("person", "alan", "")
 	v.LinkObjects(book.ID, "author", alan.ID)
 
 	// Bidirectional link creates 2 DB rows: forward (author) + inverse (books)
@@ -45,8 +45,8 @@ func TestVault_ListRelations_Forward(t *testing.T) {
 
 func TestVault_ListRelations_BothDirections(t *testing.T) {
 	v := setupRelationTestVault(t)
-	book, _ := v.NewObject("book", "test")
-	alan, _ := v.NewObject("person", "alan")
+	book, _ := v.NewObject("book", "test", "")
+	alan, _ := v.NewObject("person", "alan", "")
 	v.LinkObjects(book.ID, "author", alan.ID)
 
 	// person/alan should have both: inverse (books, from_id=person/alan) + forward (author, to_id=person/alan)

--- a/core/relation_test.go
+++ b/core/relation_test.go
@@ -42,8 +42,8 @@ properties:
 func TestVault_LinkObjects_SingleValue(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	book, _ := v.NewObject("book", "golang-in-action")
-	person, _ := v.NewObject("person", "alan-donovan")
+	book, _ := v.NewObject("book", "golang-in-action", "")
+	person, _ := v.NewObject("person", "alan-donovan", "")
 
 	err := v.LinkObjects(book.ID, "author", person.ID)
 	if err != nil {
@@ -83,9 +83,9 @@ func TestVault_LinkObjects_SingleValue(t *testing.T) {
 func TestVault_LinkObjects_MultipleValue(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	bookA, _ := v.NewObject("book", "book-a")
-	bookB, _ := v.NewObject("book", "book-b")
-	person, _ := v.NewObject("person", "alan")
+	bookA, _ := v.NewObject("book", "book-a", "")
+	bookB, _ := v.NewObject("book", "book-b", "")
+	person, _ := v.NewObject("person", "alan", "")
 
 	// Link two books to person via inverse (person.books is multiple)
 	v.LinkObjects(bookA.ID, "author", person.ID)
@@ -103,7 +103,7 @@ func TestVault_LinkObjects_MultipleValue(t *testing.T) {
 
 func TestVault_LinkObjects_TargetNotFound(t *testing.T) {
 	v := setupRelationTestVault(t)
-	book, _ := v.NewObject("book", "test")
+	book, _ := v.NewObject("book", "test", "")
 
 	err := v.LinkObjects(book.ID, "author", "person/nonexistent")
 	if err == nil {
@@ -113,8 +113,8 @@ func TestVault_LinkObjects_TargetNotFound(t *testing.T) {
 
 func TestVault_LinkObjects_RelationNotFound(t *testing.T) {
 	v := setupRelationTestVault(t)
-	book, _ := v.NewObject("book", "test")
-	person, _ := v.NewObject("person", "alan")
+	book, _ := v.NewObject("book", "test", "")
+	person, _ := v.NewObject("person", "alan", "")
 
 	err := v.LinkObjects(book.ID, "nonexistent", person.ID)
 	if err == nil {
@@ -124,8 +124,8 @@ func TestVault_LinkObjects_RelationNotFound(t *testing.T) {
 
 func TestVault_LinkObjects_TypeMismatch(t *testing.T) {
 	v := setupRelationTestVault(t)
-	bookA, _ := v.NewObject("book", "book-a")
-	bookB, _ := v.NewObject("book", "book-b")
+	bookA, _ := v.NewObject("book", "book-a", "")
+	bookB, _ := v.NewObject("book", "book-b", "")
 
 	// author targets person, not book
 	err := v.LinkObjects(bookA.ID, "author", bookB.ID)
@@ -148,9 +148,9 @@ func TestVault_LinkObjects_DBNotOpen(t *testing.T) {
 func TestVault_LinkObjects_SingleValueOverwrite(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	book, _ := v.NewObject("book", "test")
-	alan, _ := v.NewObject("person", "alan")
-	brian, _ := v.NewObject("person", "brian")
+	book, _ := v.NewObject("book", "test", "")
+	alan, _ := v.NewObject("person", "alan", "")
+	brian, _ := v.NewObject("person", "brian", "")
 
 	// Link to alan first
 	v.LinkObjects(book.ID, "author", alan.ID)
@@ -170,8 +170,8 @@ func TestVault_LinkObjects_SingleValueOverwrite(t *testing.T) {
 func TestVault_LinkObjects_DuplicateMultiple(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	book, _ := v.NewObject("book", "test")
-	alan, _ := v.NewObject("person", "alan")
+	book, _ := v.NewObject("book", "test", "")
+	alan, _ := v.NewObject("person", "alan", "")
 
 	v.LinkObjects(book.ID, "author", alan.ID)
 
@@ -186,8 +186,8 @@ func TestVault_LinkObjects_DuplicateMultiple(t *testing.T) {
 func TestVault_UnlinkObjects_SingleValue(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	book, _ := v.NewObject("book", "test")
-	alan, _ := v.NewObject("person", "alan")
+	book, _ := v.NewObject("book", "test", "")
+	alan, _ := v.NewObject("person", "alan", "")
 	v.LinkObjects(book.ID, "author", alan.ID)
 
 	// Unlink without --both: only remove from book
@@ -212,8 +212,8 @@ func TestVault_UnlinkObjects_SingleValue(t *testing.T) {
 func TestVault_UnlinkObjects_Both(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	book, _ := v.NewObject("book", "test")
-	alan, _ := v.NewObject("person", "alan")
+	book, _ := v.NewObject("book", "test", "")
+	alan, _ := v.NewObject("person", "alan", "")
 	v.LinkObjects(book.ID, "author", alan.ID)
 
 	err := v.UnlinkObjects(book.ID, "author", alan.ID, true)
@@ -242,9 +242,9 @@ func TestVault_UnlinkObjects_Both(t *testing.T) {
 func TestVault_UnlinkObjects_MultipleRemoveOne(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	bookA, _ := v.NewObject("book", "book-a")
-	bookB, _ := v.NewObject("book", "book-b")
-	alan, _ := v.NewObject("person", "alan")
+	bookA, _ := v.NewObject("book", "book-a", "")
+	bookB, _ := v.NewObject("book", "book-b", "")
+	alan, _ := v.NewObject("person", "alan", "")
 
 	v.LinkObjects(bookA.ID, "author", alan.ID)
 	v.LinkObjects(bookB.ID, "author", alan.ID)
@@ -310,8 +310,8 @@ func TestFindSystemRelationProperty_Nonexistent(t *testing.T) {
 func TestVault_LinkObjects_SystemRelationTags(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	tag, _ := v.NewObject("tag", "go")
-	book, _ := v.NewObject("book", "golang-book")
+	tag, _ := v.NewObject("tag", "go", "")
+	book, _ := v.NewObject("book", "golang-book", "")
 
 	err := v.LinkObjects(book.ID, TagsProperty, tag.ID)
 	if err != nil {
@@ -331,8 +331,8 @@ func TestVault_LinkObjects_SystemRelationTags(t *testing.T) {
 func TestVault_UnlinkObjects_SystemRelationTags(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	tag, _ := v.NewObject("tag", "go")
-	book, _ := v.NewObject("book", "golang-book")
+	tag, _ := v.NewObject("tag", "go", "")
+	book, _ := v.NewObject("book", "golang-book", "")
 
 	v.LinkObjects(book.ID, TagsProperty, tag.ID)
 

--- a/core/sync.go
+++ b/core/sync.go
@@ -316,7 +316,7 @@ func (v *Vault) syncTagRelations(ctx *syncContext) error {
 					if existingID, exists := tagNameIndex[slug]; exists {
 						tagID = existingID
 					} else {
-						newTag, err := v.NewObject(TagTypeName, slug)
+						newTag, err := v.NewObject(TagTypeName, slug, "")
 						if err != nil {
 							continue
 						}

--- a/core/sync_test.go
+++ b/core/sync_test.go
@@ -41,7 +41,7 @@ func TestVault_SyncIndex_UpdatedFile(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"), []byte("name: book\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
 	// Create via API (body is empty in DB)
-	obj, _ := v.NewObject("book", "test-book")
+	obj, _ := v.NewObject("book", "test-book", "")
 
 	// Manually edit the file to add body
 	objPath := v.ObjectPath(obj.Type, obj.Filename)
@@ -69,7 +69,7 @@ func TestVault_SyncIndex_DeletedFile(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"), []byte("name: book\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
 	// Create via API
-	obj, _ := v.NewObject("book", "test-book")
+	obj, _ := v.NewObject("book", "test-book", "")
 
 	// Delete the file
 	os.Remove(v.ObjectPath(obj.Type, obj.Filename))
@@ -106,8 +106,8 @@ func TestVault_SyncIndex_OrphanedRelations(t *testing.T) {
 	v := setupRelationTestVault(t)
 
 	// Create two objects and link them
-	book, _ := v.NewObject("book", "golang-in-action")
-	person, _ := v.NewObject("person", "alan-donovan")
+	book, _ := v.NewObject("book", "golang-in-action", "")
+	person, _ := v.NewObject("person", "alan-donovan", "")
 	v.LinkObjects(book.ID, "author", person.ID)
 
 	// Verify relations exist
@@ -151,8 +151,8 @@ func TestVault_SyncIndex_OrphanedRelations(t *testing.T) {
 func TestVault_SyncIndex_NoOrphansWhenAllExist(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	book, _ := v.NewObject("book", "test-book")
-	alan, _ := v.NewObject("person", "alan")
+	book, _ := v.NewObject("book", "test-book", "")
+	alan, _ := v.NewObject("person", "alan", "")
 	v.LinkObjects(book.ID, "author", alan.ID)
 
 	result, err := v.SyncIndex()
@@ -175,8 +175,8 @@ func TestVault_SyncIndex_NoOrphansWhenAllExist(t *testing.T) {
 func TestVault_SyncIndex_OrphanFromSourceDeletion(t *testing.T) {
 	v := setupRelationTestVault(t)
 
-	book, _ := v.NewObject("book", "test-book")
-	alan, _ := v.NewObject("person", "alan")
+	book, _ := v.NewObject("book", "test-book", "")
+	alan, _ := v.NewObject("person", "alan", "")
 	v.LinkObjects(book.ID, "author", alan.ID)
 
 	// Delete the source (book) instead of the target

--- a/core/system_property.go
+++ b/core/system_property.go
@@ -16,10 +16,11 @@ const (
 // SystemProperty defines a system-managed property that is automatically
 // present on all objects, regardless of type schema.
 type SystemProperty struct {
-	Name     string
-	Type     string
-	Target   string // only for relation type
-	Multiple bool   // only for relation type
+	Name      string
+	Type      string
+	Target    string // only for relation type
+	Multiple  bool   // only for relation type
+	Immutable bool   // true for auto-managed properties (created_at, updated_at)
 }
 
 // systemProperties is the authoritative registry of all system properties.
@@ -27,8 +28,8 @@ type SystemProperty struct {
 var systemProperties = []SystemProperty{
 	{Name: NameProperty, Type: "text"},
 	{Name: DescriptionProperty, Type: "text"},
-	{Name: CreatedAtProperty, Type: "datetime"},
-	{Name: UpdatedAtProperty, Type: "datetime"},
+	{Name: CreatedAtProperty, Type: "datetime", Immutable: true},
+	{Name: UpdatedAtProperty, Type: "datetime", Immutable: true},
 	{Name: TagsProperty, Type: "relation", Target: TagTypeName, Multiple: true},
 }
 
@@ -37,6 +38,17 @@ func IsSystemProperty(name string) bool {
 	for _, sp := range systemProperties {
 		if sp.Name == name {
 			return true
+		}
+	}
+	return false
+}
+
+// IsImmutableSystemProperty returns true if the given name is an immutable
+// (auto-managed) system property that cannot be overridden by templates.
+func IsImmutableSystemProperty(name string) bool {
+	for _, sp := range systemProperties {
+		if sp.Name == name {
+			return sp.Immutable
 		}
 	}
 	return false

--- a/core/system_property_test.go
+++ b/core/system_property_test.go
@@ -53,6 +53,50 @@ func TestSystemPropertyNames_ReturnsNewSlice(t *testing.T) {
 	}
 }
 
+// ── Immutability tests ──────────────────────────────────────────────────────
+
+func TestIsImmutableSystemProperty_CreatedAt(t *testing.T) {
+	if !IsImmutableSystemProperty("created_at") {
+		t.Error("created_at should be immutable")
+	}
+}
+
+func TestIsImmutableSystemProperty_UpdatedAt(t *testing.T) {
+	if !IsImmutableSystemProperty("updated_at") {
+		t.Error("updated_at should be immutable")
+	}
+}
+
+func TestIsImmutableSystemProperty_Name(t *testing.T) {
+	if IsImmutableSystemProperty("name") {
+		t.Error("name should not be immutable")
+	}
+}
+
+func TestIsImmutableSystemProperty_Description(t *testing.T) {
+	if IsImmutableSystemProperty("description") {
+		t.Error("description should not be immutable")
+	}
+}
+
+func TestIsImmutableSystemProperty_Tags(t *testing.T) {
+	if IsImmutableSystemProperty("tags") {
+		t.Error("tags should not be immutable")
+	}
+}
+
+func TestIsImmutableSystemProperty_NonSystemProperty(t *testing.T) {
+	if IsImmutableSystemProperty("title") {
+		t.Error("non-system property should not be immutable")
+	}
+}
+
+func TestIsImmutableSystemProperty_EmptyString(t *testing.T) {
+	if IsImmutableSystemProperty("") {
+		t.Error("empty string should not be immutable")
+	}
+}
+
 // ── Tags system property tests (2.5) ────────────────────────────────────────
 
 func TestIsSystemProperty_Tags(t *testing.T) {
@@ -180,7 +224,7 @@ func TestValidateSharedProperties_RejectsAllSystemProperties(t *testing.T) {
 func TestNewObject_TimestampFormat(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "test")
+	obj, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -210,7 +254,7 @@ func TestNewObject_TimestampFormat(t *testing.T) {
 func TestNewObject_CreatedAtAndUpdatedAtMatch(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "test")
+	obj, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -227,7 +271,7 @@ func TestNewObject_CreatedAtAndUpdatedAtMatch(t *testing.T) {
 func TestSaveObject_UpdatesUpdatedAt(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "test")
+	obj, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -267,7 +311,7 @@ func TestSaveObject_UpdatesUpdatedAt(t *testing.T) {
 func TestSetProperty_UpdatesUpdatedAt(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "test")
+	obj, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}
@@ -400,7 +444,7 @@ func TestOrderedPropKeys_NoSchema(t *testing.T) {
 func TestNewObject_DoesNotIncludeDescription(t *testing.T) {
 	v := setupTestVault(t)
 
-	obj, err := v.NewObject("book", "test")
+	obj, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}

--- a/core/tag_test.go
+++ b/core/tag_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestResolveTagReference_ByID(t *testing.T) {
 	v := setupTestVault(t)
-	tag, _ := v.NewObject("tag", "go")
+	tag, _ := v.NewObject("tag", "go", "")
 
 	diskTags := map[string]*Object{tag.ID: tag}
 	nameIndex := map[string]string{"go": tag.ID}
@@ -24,7 +24,7 @@ func TestResolveTagReference_ByID(t *testing.T) {
 
 func TestResolveTagReference_ByName(t *testing.T) {
 	v := setupTestVault(t)
-	tag, _ := v.NewObject("tag", "go")
+	tag, _ := v.NewObject("tag", "go", "")
 
 	diskTags := map[string]*Object{tag.ID: tag}
 	nameIndex := map[string]string{"go": tag.ID}
@@ -72,10 +72,10 @@ func TestSyncIndex_TagRelationsWritten(t *testing.T) {
 	v := setupTestVault(t)
 
 	// Create a tag object
-	tag, _ := v.NewObject("tag", "go")
+	tag, _ := v.NewObject("tag", "go", "")
 
 	// Create a book with tags referencing the tag by name
-	book, _ := v.NewObject("book", "golang-book")
+	book, _ := v.NewObject("book", "golang-book", "")
 	book.Properties[TagsProperty] = []any{"tag/go"}
 	v.SaveObject(book)
 
@@ -107,7 +107,7 @@ func TestSyncIndex_AutoCreateTag(t *testing.T) {
 	v := setupTestVault(t)
 
 	// Create a book referencing a tag that doesn't exist
-	book, _ := v.NewObject("book", "golang-book")
+	book, _ := v.NewObject("book", "golang-book", "")
 	book.Properties[TagsProperty] = []any{"tag/auto-created"}
 	v.SaveObject(book)
 
@@ -142,7 +142,7 @@ func TestSyncIndex_AutoCreateTag(t *testing.T) {
 func TestSyncIndex_TagPreservedInFiltering(t *testing.T) {
 	v := setupTestVault(t)
 
-	tag, _ := v.NewObject("tag", "go")
+	tag, _ := v.NewObject("tag", "go", "")
 
 	// Write a raw book file with tags in frontmatter
 	ulid, _ := GenerateULID()

--- a/core/template.go
+++ b/core/template.go
@@ -1,0 +1,105 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Template represents a parsed object template with frontmatter properties and body.
+type Template struct {
+	Name       string
+	Properties map[string]any
+	Body       string
+}
+
+// ListTemplates returns the names of all templates available for the given type.
+// Template names are derived from filenames (without .md extension) in templates/<type>/.
+// Returns an empty slice if no templates directory exists or it contains no .md files.
+func (v *Vault) ListTemplates(typeName string) ([]string, error) {
+	dir := v.TypeTemplatesDir(typeName)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read templates directory: %w", err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if name, ok := strings.CutSuffix(e.Name(), ".md"); ok {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// LoadTemplate reads and parses a template file for the given type and template name.
+// Returns the parsed template with frontmatter properties and body content.
+func (v *Vault) LoadTemplate(typeName, templateName string) (*Template, error) {
+	path := v.TemplatePath(typeName, templateName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("template %q not found for type %q", templateName, typeName)
+		}
+		return nil, fmt.Errorf("read template: %w", err)
+	}
+
+	// Handle template files with no frontmatter delimiter
+	content := string(data)
+	if len(data) > 0 && !strings.HasPrefix(content, "---") {
+		if !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		return &Template{
+			Name:       templateName,
+			Properties: make(map[string]any),
+			Body:       content,
+		}, nil
+	}
+
+	props, body, err := parseFrontmatter(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse template frontmatter: %w", err)
+	}
+
+	return &Template{
+		Name:       templateName,
+		Properties: props,
+		Body:       body,
+	}, nil
+}
+
+// filterTemplateProperties returns only the template properties that should be applied.
+// It excludes immutable system properties and properties not defined in the schema.
+func filterTemplateProperties(tmplProps map[string]any, schema *TypeSchema) map[string]any {
+	if len(tmplProps) == 0 {
+		return nil
+	}
+
+	filtered := make(map[string]any)
+	validProps := schema.PropertyNames()
+
+	for key, val := range tmplProps {
+		// Skip immutable system properties
+		if IsImmutableSystemProperty(key) {
+			continue
+		}
+		// Allow mutable system properties
+		if IsSystemProperty(key) {
+			filtered[key] = val
+			continue
+		}
+		// Allow schema-defined properties
+		if validProps[key] {
+			filtered[key] = val
+		}
+	}
+
+	return filtered
+}

--- a/core/template_test.go
+++ b/core/template_test.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestListTemplates_IgnoresNonMdFiles(t *testing.T) {
+	v := setupTestVault(t)
+
+	dir := v.TypeTemplatesDir("book")
+	os.MkdirAll(dir, 0755)
+	os.WriteFile(filepath.Join(dir, "review.md"), []byte("## Review\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("not a template"), 0644)
+	os.WriteFile(filepath.Join(dir, ".hidden"), []byte("hidden file"), 0644)
+
+	names, err := v.ListTemplates("book")
+	if err != nil {
+		t.Fatalf("ListTemplates() error = %v", err)
+	}
+	if len(names) != 1 {
+		t.Fatalf("expected 1 template, got %d: %v", len(names), names)
+	}
+	if names[0] != "review" {
+		t.Errorf("expected 'review', got %q", names[0])
+	}
+}
+
+func TestListTemplates_IgnoresNestedDirectories(t *testing.T) {
+	v := setupTestVault(t)
+
+	dir := v.TypeTemplatesDir("book")
+	os.MkdirAll(filepath.Join(dir, "subdir"), 0755)
+	os.WriteFile(filepath.Join(dir, "review.md"), []byte("## Review\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "subdir", "nested.md"), []byte("## Nested\n"), 0644)
+
+	names, err := v.ListTemplates("book")
+	if err != nil {
+		t.Fatalf("ListTemplates() error = %v", err)
+	}
+	if len(names) != 1 {
+		t.Fatalf("expected 1 template, got %d: %v", len(names), names)
+	}
+	if names[0] != "review" {
+		t.Errorf("expected 'review', got %q", names[0])
+	}
+}
+
+func TestFilterTemplateProperties_SkipsImmutable(t *testing.T) {
+	schema := &TypeSchema{
+		Properties: []Property{{Name: "status", Type: "string"}},
+	}
+	tmplProps := map[string]any{
+		"status":     "draft",
+		"created_at": "2020-01-01T00:00:00Z",
+		"updated_at": "2020-01-01T00:00:00Z",
+	}
+
+	filtered := filterTemplateProperties(tmplProps, schema)
+	if _, ok := filtered["created_at"]; ok {
+		t.Error("created_at should be filtered out")
+	}
+	if _, ok := filtered["updated_at"]; ok {
+		t.Error("updated_at should be filtered out")
+	}
+	if filtered["status"] != "draft" {
+		t.Errorf("status = %v, want 'draft'", filtered["status"])
+	}
+}
+
+func TestFilterTemplateProperties_AllowsMutableSystemProps(t *testing.T) {
+	schema := &TypeSchema{}
+	tmplProps := map[string]any{
+		"name":        "custom-name",
+		"description": "A description",
+	}
+
+	filtered := filterTemplateProperties(tmplProps, schema)
+	if filtered["name"] != "custom-name" {
+		t.Errorf("name = %v, want 'custom-name'", filtered["name"])
+	}
+	if filtered["description"] != "A description" {
+		t.Errorf("description = %v, want 'A description'", filtered["description"])
+	}
+}
+
+func TestFilterTemplateProperties_SkipsUnknownProps(t *testing.T) {
+	schema := &TypeSchema{
+		Properties: []Property{{Name: "status", Type: "string"}},
+	}
+	tmplProps := map[string]any{
+		"status":  "draft",
+		"unknown": "value",
+	}
+
+	filtered := filterTemplateProperties(tmplProps, schema)
+	if _, ok := filtered["unknown"]; ok {
+		t.Error("unknown property should be filtered out")
+	}
+	if filtered["status"] != "draft" {
+		t.Errorf("status = %v, want 'draft'", filtered["status"])
+	}
+}

--- a/core/validate_test.go
+++ b/core/validate_test.go
@@ -53,7 +53,7 @@ func TestValidateAllObjects_Valid(t *testing.T) {
 	schema := []byte("name: book\nproperties:\n  - name: title\n    type: string\n")
 	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"), schema, 0644)
 
-	obj, err := v.NewObject("book", "test-book")
+	obj, err := v.NewObject("book", "test-book", "")
 	if err != nil {
 		t.Fatalf("NewObject error = %v", err)
 	}
@@ -70,7 +70,7 @@ func TestValidateAllObjects_Invalid(t *testing.T) {
 	schema := []byte("name: book\nproperties:\n  - name: rating\n    type: number\n")
 	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"), schema, 0644)
 
-	obj, err := v.NewObject("book", "bad-book")
+	obj, err := v.NewObject("book", "bad-book", "")
 	if err != nil {
 		t.Fatalf("NewObject error = %v", err)
 	}
@@ -98,8 +98,8 @@ func TestValidateRelations_Valid(t *testing.T) {
 	personSchema := []byte("name: person\nproperties:\n  - name: name\n    type: string\n")
 	os.WriteFile(filepath.Join(v.TypesDir(), "person.yaml"), personSchema, 0644)
 
-	book, _ := v.NewObject("book", "test-book")
-	alice, _ := v.NewObject("person", "alice")
+	book, _ := v.NewObject("book", "test-book", "")
+	alice, _ := v.NewObject("person", "alice", "")
 	v.LinkObjects(book.ID, "author", alice.ID)
 
 	errs := ValidateRelations(v)
@@ -159,8 +159,8 @@ func TestValidateWikiLinks_NoBrokenLinks(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "note.yaml"),
 		[]byte("name: note\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
-	noteA, _ := v.NewObject("note", "alpha")
-	noteB, _ := v.NewObject("note", "beta")
+	noteA, _ := v.NewObject("note", "alpha", "")
+	noteB, _ := v.NewObject("note", "beta", "")
 
 	body := fmt.Sprintf("---\ntitle: Alpha\n---\n\nSee [[%s]].\n", noteB.ID)
 	os.WriteFile(v.ObjectPath(noteA.Type, noteA.Filename), []byte(body), 0644)
@@ -178,7 +178,7 @@ func TestValidateWikiLinks_BrokenLink(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "note.yaml"),
 		[]byte("name: note\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
-	note, _ := v.NewObject("note", "alpha")
+	note, _ := v.NewObject("note", "alpha", "")
 
 	body := "---\ntitle: Alpha\n---\n\nSee [[note/nonexistent-01jjjjjjjjjjjjjjjjjjjjjjjj]].\n"
 	os.WriteFile(v.ObjectPath(note.Type, note.Filename), []byte(body), 0644)
@@ -208,8 +208,8 @@ func TestValidateWikiLinks_NoWikiLinks(t *testing.T) {
 
 func TestValidateNameUniqueness_NoDuplicates(t *testing.T) {
 	v := setupTestVault(t)
-	v.NewObject("tag", "go")
-	v.NewObject("tag", "rust")
+	v.NewObject("tag", "go", "")
+	v.NewObject("tag", "rust", "")
 
 	errs := ValidateNameUniqueness(v)
 	if len(errs) != 0 {
@@ -219,8 +219,8 @@ func TestValidateNameUniqueness_NoDuplicates(t *testing.T) {
 
 func TestValidateNameUniqueness_CaseSensitive(t *testing.T) {
 	v := setupTestVault(t)
-	v.NewObject("tag", "Go")
-	v.NewObject("tag", "go")
+	v.NewObject("tag", "Go", "")
+	v.NewObject("tag", "go", "")
 
 	errs := ValidateNameUniqueness(v)
 	if len(errs) != 0 {
@@ -230,11 +230,11 @@ func TestValidateNameUniqueness_CaseSensitive(t *testing.T) {
 
 func TestNewObject_TagNameDuplicate(t *testing.T) {
 	v := setupTestVault(t)
-	_, err := v.NewObject("tag", "go")
+	_, err := v.NewObject("tag", "go", "")
 	if err != nil {
 		t.Fatalf("first NewObject error = %v", err)
 	}
-	_, err = v.NewObject("tag", "go")
+	_, err = v.NewObject("tag", "go", "")
 	if err == nil {
 		t.Fatal("expected error for duplicate tag name, got nil")
 	}
@@ -245,11 +245,11 @@ func TestNewObject_TagNameDuplicate(t *testing.T) {
 
 func TestNewObject_NonTagDuplicateNameAllowed(t *testing.T) {
 	v := setupTestVault(t)
-	_, err := v.NewObject("book", "test")
+	_, err := v.NewObject("book", "test", "")
 	if err != nil {
 		t.Fatalf("first book error = %v", err)
 	}
-	_, err = v.NewObject("book", "test")
+	_, err = v.NewObject("book", "test", "")
 	if err != nil {
 		t.Errorf("second book with same name should be allowed, got %v", err)
 	}

--- a/core/vault.go
+++ b/core/vault.go
@@ -46,6 +46,21 @@ func (v *Vault) DBPath() string {
 	return filepath.Join(v.Dir(), "index.db")
 }
 
+// TemplatesDir returns the templates directory path.
+func (v *Vault) TemplatesDir() string {
+	return filepath.Join(v.Root, "templates")
+}
+
+// TypeTemplatesDir returns the directory path for a specific type's templates.
+func (v *Vault) TypeTemplatesDir(typeName string) string {
+	return filepath.Join(v.TemplatesDir(), typeName)
+}
+
+// TemplatePath returns the file path for a specific template.
+func (v *Vault) TemplatePath(typeName, templateName string) string {
+	return filepath.Join(v.TypeTemplatesDir(typeName), templateName+".md")
+}
+
 // ObjectsDir returns the objects directory path.
 func (v *Vault) ObjectsDir() string {
 	return filepath.Join(v.Root, "objects")

--- a/core/vault_test.go
+++ b/core/vault_test.go
@@ -122,6 +122,15 @@ func TestVault_Paths(t *testing.T) {
 	if got := v.ObjectsDir(); got != filepath.Join("/some/root", "objects") {
 		t.Errorf("ObjectsDir() = %q", got)
 	}
+	if got := v.TemplatesDir(); got != filepath.Join("/some/root", "templates") {
+		t.Errorf("TemplatesDir() = %q, want %q", got, filepath.Join("/some/root", "templates"))
+	}
+	if got := v.TypeTemplatesDir("book"); got != filepath.Join("/some/root", "templates", "book") {
+		t.Errorf("TypeTemplatesDir() = %q, want %q", got, filepath.Join("/some/root", "templates", "book"))
+	}
+	if got := v.TemplatePath("book", "review"); got != filepath.Join("/some/root", "templates", "book", "review.md") {
+		t.Errorf("TemplatePath() = %q, want %q", got, filepath.Join("/some/root", "templates", "book", "review.md"))
+	}
 }
 
 func TestVault_Open_Close(t *testing.T) {
@@ -176,7 +185,7 @@ func TestVault_FTSTrigger_InsertSync(t *testing.T) {
 	v := setupTestVault(t)
 
 	// NewObject INSERT should auto-sync FTS via trigger
-	obj, err := v.NewObject("book", "golang-in-action")
+	obj, err := v.NewObject("book", "golang-in-action", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}

--- a/core/wikilink_db_test.go
+++ b/core/wikilink_db_test.go
@@ -18,8 +18,8 @@ func TestVault_SyncIndex_WikiLinks(t *testing.T) {
 		[]byte("name: person\nproperties:\n  - name: name\n    type: string\n"), 0644)
 
 	// Create objects
-	book, _ := v.NewObject("book", "clean-code")
-	person, _ := v.NewObject("person", "robert-martin")
+	book, _ := v.NewObject("book", "clean-code", "")
+	person, _ := v.NewObject("person", "robert-martin", "")
 
 	// Edit book's body to include a wiki-link using full object ID
 	bookPath := v.ObjectPath(book.Type, book.Filename)
@@ -65,7 +65,7 @@ func TestVault_SyncIndex_WikiLinks_BrokenLink(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "book.yaml"),
 		[]byte("name: book\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
-	book, _ := v.NewObject("book", "clean-code")
+	book, _ := v.NewObject("book", "clean-code", "")
 
 	// Link to a non-existent object (full ID that doesn't exist)
 	bookPath := v.ObjectPath(book.Type, book.Filename)
@@ -98,9 +98,9 @@ func TestVault_SyncIndex_WikiLinks_Updated(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "person.yaml"),
 		[]byte("name: person\nproperties:\n  - name: name\n    type: string\n"), 0644)
 
-	book, _ := v.NewObject("book", "clean-code")
-	personA, _ := v.NewObject("person", "alice")
-	personB, _ := v.NewObject("person", "bob")
+	book, _ := v.NewObject("book", "clean-code", "")
+	personA, _ := v.NewObject("person", "alice", "")
+	personB, _ := v.NewObject("person", "bob", "")
 
 	// First sync: link to alice
 	bookPath := v.ObjectPath(book.Type, book.Filename)
@@ -140,8 +140,8 @@ func TestVault_SyncIndex_WikiLinks_DisplayText(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "person.yaml"),
 		[]byte("name: person\nproperties:\n  - name: name\n    type: string\n"), 0644)
 
-	book, _ := v.NewObject("book", "clean-code")
-	person, _ := v.NewObject("person", "robert-martin")
+	book, _ := v.NewObject("book", "clean-code", "")
+	person, _ := v.NewObject("person", "robert-martin", "")
 
 	bookPath := v.ObjectPath(book.Type, book.Filename)
 	body := fmt.Sprintf("---\ntitle: Clean Code\n---\n\nBy [[%s|Uncle Bob]].\n", person.ID)
@@ -169,8 +169,8 @@ func TestVault_SyncIndex_WikiLinks_CleanedOnObjectDeletion(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "person.yaml"),
 		[]byte("name: person\nproperties:\n  - name: name\n    type: string\n"), 0644)
 
-	book, _ := v.NewObject("book", "clean-code")
-	person, _ := v.NewObject("person", "robert-martin")
+	book, _ := v.NewObject("book", "clean-code", "")
+	person, _ := v.NewObject("person", "robert-martin", "")
 
 	bookPath := v.ObjectPath(book.Type, book.Filename)
 	body := fmt.Sprintf("---\ntitle: Clean Code\n---\n\nBy [[%s]].\n", person.ID)
@@ -226,9 +226,9 @@ func TestVault_ListBacklinks_MultipleSourcesSorted(t *testing.T) {
 	os.WriteFile(filepath.Join(v.TypesDir(), "note.yaml"),
 		[]byte("name: note\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
-	target, _ := v.NewObject("note", "target")
-	noteA, _ := v.NewObject("note", "alpha")
-	noteB, _ := v.NewObject("note", "beta")
+	target, _ := v.NewObject("note", "target", "")
+	noteA, _ := v.NewObject("note", "alpha", "")
+	noteB, _ := v.NewObject("note", "beta", "")
 
 	// Both notes link to target using full ID
 	os.WriteFile(v.ObjectPath(noteA.Type, noteA.Filename),

--- a/examples/book-vault/templates/book/quick-note.md
+++ b/examples/book-vault/templates/book/quick-note.md
@@ -1,0 +1,7 @@
+---
+status: to-read
+---
+
+## Why I Want to Read This
+
+## Notes

--- a/examples/book-vault/templates/book/review.md
+++ b/examples/book-vault/templates/book/review.md
@@ -1,0 +1,11 @@
+---
+status: reading
+---
+
+## Summary
+
+## Key Takeaways
+
+## Favorite Quotes
+
+## Rating & Thoughts

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -35,7 +35,7 @@ func setupTestVault(t *testing.T) (*core.Vault, string) {
 	}
 
 	// Create sample object
-	obj, err := v.NewObject("book", "clean-code")
+	obj, err := v.NewObject("book", "clean-code", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}

--- a/openspec/changes/issue-173-object-templates/.openspec.yaml
+++ b/openspec/changes/issue-173-object-templates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-14

--- a/openspec/changes/issue-173-object-templates/design.md
+++ b/openspec/changes/issue-173-object-templates/design.md
@@ -1,0 +1,83 @@
+## Context
+
+`tmd object create` currently produces objects with an empty body and only schema-default property values. Users who create structured objects (book reviews, meeting notes) must manually add boilerplate content every time. The `NewObject` method in `core/object.go` hardcodes an empty body (`""`) and initializes properties from schema defaults only.
+
+Templates are stored as regular Markdown files at `templates/<type>/` in the vault root. Each template has frontmatter (property overrides) and body (initial content). The system property registry (`SystemProperty` struct) currently lacks the ability to distinguish user-authored from auto-managed properties, which is needed to determine which system properties a template can override.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Allow types to define one or more templates as Markdown files
+- Apply templates during `tmd object create` (auto, interactive, or explicit)
+- Extend `SystemProperty` with an `Immutable` field to distinguish auto-managed properties
+- Template frontmatter overrides schema defaults for mutable system properties and schema properties
+
+**Non-Goals:**
+
+- Placeholder/variable substitution in templates (separate issue)
+- Template inheritance or composition
+- Template validation via `tmd type validate` (future enhancement)
+- TUI template selection (future enhancement)
+
+## Decisions
+
+### 1. Template storage: `templates/<type>/` at vault root
+
+**Choice:** Store templates at `templates/<type>/<name>.md` in the vault root directory.
+
+**Alternatives considered:**
+- `.typemd/templates/<type>/` — keeps templates in the config area, but templates are user-facing content, not internal config
+- `objects/<type>/_templates/` — co-locates with objects, but pollutes object scanning and requires filtering logic
+- Inline in type schema YAML — limits templates to property defaults, cannot include body content
+
+**Rationale:** Templates are user-created content (like objects), not internal metadata (like type schemas). Placing them at the vault root makes them discoverable. The `templates/` directory mirrors `objects/` as a top-level content directory. No impact on existing object scanning logic.
+
+### 2. Template file format: standard Markdown
+
+**Choice:** Templates use the same format as object files — YAML frontmatter + Markdown body.
+
+**Rationale:** No new format to learn. Users can copy an existing object as a starting template. The existing `parseFrontmatter` function can parse templates.
+
+### 3. Template selection: three modes
+
+**Choice:**
+- 0 templates → current behavior (empty body, schema defaults only)
+- 1 template → auto-apply without prompting
+- Multiple templates + no `-t` flag → interactive selection (list template names)
+- `-t <name>` flag → explicit template by name (filename without `.md`)
+
+**Rationale:** Auto-apply for single templates eliminates friction. Interactive selection for multiple templates avoids requiring users to remember template names. The `-t` flag supports scripting and power users.
+
+### 4. Property merge order
+
+**Choice:** Properties are merged in this order (later wins):
+1. Schema defaults (`Property.Default`)
+2. Template frontmatter values
+3. Auto-managed system properties (`name`, `created_at`, `updated_at`)
+
+**Rationale:** Template values override schema defaults (that's the point of templates). Auto-managed system properties always win because they must reflect actual creation state. User-authored system properties (`name`, `description`, `tags`) from templates are applied at step 2 and preserved (not overwritten at step 3).
+
+### 5. SystemProperty.Immutable field
+
+**Choice:** Add `Immutable bool` to `SystemProperty` struct. Properties with `Immutable: true` (`created_at`, `updated_at`) cannot be overridden by templates. Properties with `Immutable: false` (`name`, `description`, `tags`) can be.
+
+**Rationale:** A single boolean is sufficient — the distinction is binary (auto-managed vs user-authored). Using a field on the registry struct makes the rule declarative and easy to query when applying templates.
+
+### 6. Core API: NewObject gains templateName parameter
+
+**Choice:** Extend `NewObject(typeName, name string)` to `NewObject(typeName, name, templateName string)`. When `templateName` is non-empty, load and apply the template. When empty, behave as today.
+
+**Rationale:** Adding a parameter keeps the API simple. The CLI layer handles template discovery and selection, then passes the chosen template name to core. This keeps template selection logic (interactive prompts, `-t` flag) in `cmd/` where it belongs.
+
+### 7. Template path helpers on Vault
+
+**Choice:** Add `TemplatesDir()`, `TypeTemplatesDir(typeName)`, and `TemplatePath(typeName, templateName)` methods to `Vault`, following the existing pattern of `ObjectsDir()`, `ObjectDir()`, `ObjectPath()`.
+
+**Rationale:** Consistent with existing Vault path conventions. Centralizes path logic.
+
+## Risks / Trade-offs
+
+- **Template frontmatter with unknown properties** → Silently ignored. Template properties not in the schema are dropped during property initialization, same as how extra frontmatter in objects is handled by `SyncIndex`. This is acceptable for MVP.
+- **Template body references non-existent objects** → Not validated. Wiki-links in template body are treated as plain text until the object is synced. Acceptable for MVP.
+- **Interactive selection blocks scripting** → Mitigated by the `-t` flag which skips interactive selection. If neither `-t` nor a single template is available, the command errors in non-TTY contexts rather than hanging.

--- a/openspec/changes/issue-173-object-templates/proposal.md
+++ b/openspec/changes/issue-173-object-templates/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Every `tmd object create` produces an empty body with only schema defaults. Users who frequently create structured objects (e.g., book reviews, meeting notes, weekly journals) must manually fill in the same boilerplate content every time. Object templates let types ship pre-built content structures, reducing friction and encouraging consistent formatting.
+
+## What Changes
+
+- New `templates/<type>/` directory at project root for storing per-type templates as regular Markdown files (frontmatter + body)
+- `tmd object create` loads and applies templates during object creation:
+  - 0 templates → current behavior (empty body)
+  - 1 template → auto-apply
+  - Multiple templates → interactive selection or explicit `-t <name>` flag
+- Template frontmatter properties override schema defaults for the new object
+- Template body becomes the initial content of the new object
+- `SystemProperty` struct gains an `Immutable` field to distinguish auto-managed properties (`created_at`, `updated_at`) from user-authored ones (`name`, `description`, `tags`). Templates can only override user-authored system properties.
+- Placeholder/variable substitution in templates is explicitly out of scope (separate issue)
+
+## Capabilities
+
+### New Capabilities
+
+- `object-templates`: Template discovery, loading, selection, and application during object creation
+
+### Modified Capabilities
+
+- `system-property-registry`: Add `Immutable` field to `SystemProperty` struct to distinguish user-authored vs auto-managed properties
+
+## Impact
+
+- **core/**: `SystemProperty` struct change, new template loading/application logic in `NewObject`, new `templates/` directory convention
+- **cmd/**: `tmd object create` gains `-t` / `--template` flag, interactive template selection when multiple templates exist
+- **Existing objects**: No impact — templates only affect new object creation
+- **Vault structure**: New `templates/` directory at project root (optional, no migration needed)

--- a/openspec/changes/issue-173-object-templates/specs/object-templates/spec.md
+++ b/openspec/changes/issue-173-object-templates/specs/object-templates/spec.md
@@ -1,0 +1,178 @@
+## ADDED Requirements
+
+### Requirement: Vault provides template path helpers
+
+The `Vault` struct SHALL provide `TemplatesDir()`, `TypeTemplatesDir(typeName)`, and `TemplatePath(typeName, templateName)` methods that return paths under `templates/` at the vault root.
+
+#### Scenario: TemplatesDir returns vault root templates directory
+
+- **WHEN** `TemplatesDir()` is called on a vault rooted at `/my/vault`
+- **THEN** it SHALL return `/my/vault/templates`
+
+#### Scenario: TypeTemplatesDir returns type-specific templates directory
+
+- **WHEN** `TypeTemplatesDir("book")` is called on a vault rooted at `/my/vault`
+- **THEN** it SHALL return `/my/vault/templates/book`
+
+#### Scenario: TemplatePath returns full template file path
+
+- **WHEN** `TemplatePath("book", "review")` is called on a vault rooted at `/my/vault`
+- **THEN** it SHALL return `/my/vault/templates/book/review.md`
+
+### Requirement: ListTemplates discovers available templates for a type
+
+The `Vault` SHALL provide a `ListTemplates(typeName)` method that returns a list of template names available for the given type. Template names SHALL be derived from filenames (without the `.md` extension) in `templates/<type>/`. If the directory does not exist or is empty, it SHALL return an empty list.
+
+#### Scenario: Type has multiple templates
+
+- **WHEN** `templates/book/` contains `review.md` and `summary.md`
+- **THEN** `ListTemplates("book")` SHALL return `["review", "summary"]`
+
+#### Scenario: Type has one template
+
+- **WHEN** `templates/book/` contains `default.md`
+- **THEN** `ListTemplates("book")` SHALL return `["default"]`
+
+#### Scenario: Type has no templates directory
+
+- **WHEN** `templates/book/` does not exist
+- **THEN** `ListTemplates("book")` SHALL return an empty list
+
+#### Scenario: Type templates directory is empty
+
+- **WHEN** `templates/book/` exists but contains no `.md` files
+- **THEN** `ListTemplates("book")` SHALL return an empty list
+
+### Requirement: LoadTemplate reads and parses a template file
+
+The `Vault` SHALL provide a `LoadTemplate(typeName, templateName)` method that reads the template file and returns its parsed frontmatter properties and body content. The template file SHALL be parsed using the same frontmatter parser used for object files.
+
+#### Scenario: Template with frontmatter and body
+
+- **WHEN** `LoadTemplate("book", "review")` is called
+- **AND** `templates/book/review.md` contains frontmatter `status: draft` and body `## Notes`
+- **THEN** it SHALL return properties `{"status": "draft"}` and body `"## Notes\n"`
+
+#### Scenario: Template with body only
+
+- **WHEN** `LoadTemplate("book", "simple")` is called
+- **AND** `templates/book/simple.md` contains only body content `## My Book`
+- **THEN** it SHALL return empty properties and body `"## My Book\n"`
+
+#### Scenario: Template with frontmatter only
+
+- **WHEN** `LoadTemplate("book", "preset")` is called
+- **AND** `templates/book/preset.md` contains only frontmatter `status: reading`
+- **THEN** it SHALL return properties `{"status": "reading"}` and empty body
+
+#### Scenario: Template file not found
+
+- **WHEN** `LoadTemplate("book", "nonexistent")` is called
+- **AND** `templates/book/nonexistent.md` does not exist
+- **THEN** it SHALL return an error
+
+### Requirement: NewObject applies template when templateName is provided
+
+The `NewObject(typeName, name, templateName)` method SHALL load and apply the specified template when `templateName` is non-empty. Template frontmatter properties SHALL override schema defaults. Template body SHALL become the initial body of the new object. When `templateName` is empty, behavior SHALL be identical to the current implementation (empty body, schema defaults only).
+
+#### Scenario: Object created with template providing body and properties
+
+- **WHEN** `NewObject("book", "my-book", "review")` is called
+- **AND** the `review` template has frontmatter `status: draft` and body `## Review Notes`
+- **THEN** the created object SHALL have `status: draft` and body `## Review Notes`
+
+#### Scenario: Object created with template overriding schema default
+
+- **WHEN** `NewObject("book", "my-book", "review")` is called
+- **AND** the schema defines `status` with default `to-read`
+- **AND** the `review` template has frontmatter `status: draft`
+- **THEN** the created object SHALL have `status: draft` (template wins over schema default)
+
+#### Scenario: Object created without template
+
+- **WHEN** `NewObject("book", "my-book", "")` is called
+- **THEN** the created object SHALL have an empty body and schema default values (current behavior)
+
+#### Scenario: Template provides mutable system property name
+
+- **WHEN** `NewObject("book", "", "daily")` is called
+- **AND** the `daily` template has frontmatter `name: daily-reading`
+- **THEN** the created object SHALL have `name: daily-reading`
+
+#### Scenario: Template provides mutable system property description
+
+- **WHEN** `NewObject("book", "my-book", "review")` is called
+- **AND** the `review` template has frontmatter `description: A book review`
+- **THEN** the created object SHALL have `description: A book review`
+
+#### Scenario: Template provides immutable system property created_at
+
+- **WHEN** `NewObject("book", "my-book", "review")` is called
+- **AND** the `review` template has frontmatter `created_at: 2020-01-01T00:00:00Z`
+- **THEN** the created object SHALL have `created_at` set to the actual creation time, NOT the template value
+
+#### Scenario: Template provides immutable system property updated_at
+
+- **WHEN** `NewObject("book", "my-book", "review")` is called
+- **AND** the `review` template has frontmatter `updated_at: 2020-01-01T00:00:00Z`
+- **THEN** the created object SHALL have `updated_at` set to the actual creation time, NOT the template value
+
+#### Scenario: Template specifies nonexistent template name
+
+- **WHEN** `NewObject("book", "my-book", "nonexistent")` is called
+- **AND** no template named `nonexistent` exists for type `book`
+- **THEN** it SHALL return an error
+
+#### Scenario: Template property not in schema is ignored
+
+- **WHEN** `NewObject("book", "my-book", "review")` is called
+- **AND** the `review` template has frontmatter `unknown_prop: value`
+- **AND** the schema does not define `unknown_prop`
+- **THEN** the created object SHALL NOT include `unknown_prop` in its properties
+
+### Requirement: CLI create command supports template flag
+
+The `tmd object create` command SHALL accept an optional `-t` / `--template` flag to specify a template name. When the flag is provided, it SHALL pass the template name to `NewObject`.
+
+#### Scenario: Create with explicit template flag
+
+- **WHEN** `tmd object create book my-book -t review` is executed
+- **THEN** the object SHALL be created using the `review` template
+
+#### Scenario: Create with long template flag
+
+- **WHEN** `tmd object create book my-book --template review` is executed
+- **THEN** the object SHALL be created using the `review` template
+
+### Requirement: CLI auto-applies single template
+
+When a type has exactly one template and no `-t` flag is specified, `tmd object create` SHALL automatically apply that template.
+
+#### Scenario: Single template auto-applied
+
+- **WHEN** `tmd object create book my-book` is executed
+- **AND** `templates/book/` contains only `default.md`
+- **THEN** the object SHALL be created using the `default` template
+
+#### Scenario: No templates available
+
+- **WHEN** `tmd object create book my-book` is executed
+- **AND** `templates/book/` does not exist
+- **THEN** the object SHALL be created with empty body and schema defaults (current behavior)
+
+### Requirement: CLI prompts for template selection when multiple exist
+
+When a type has multiple templates and no `-t` flag is specified, `tmd object create` SHALL present an interactive selection prompt listing available template names. The user selects one, and that template is applied.
+
+#### Scenario: Multiple templates trigger interactive selection
+
+- **WHEN** `tmd object create book my-book` is executed
+- **AND** `templates/book/` contains `review.md` and `summary.md`
+- **THEN** the command SHALL prompt the user to select between `review` and `summary`
+- **AND** apply the selected template
+
+#### Scenario: Multiple templates with -t flag skips prompt
+
+- **WHEN** `tmd object create book my-book -t review` is executed
+- **AND** `templates/book/` contains `review.md` and `summary.md`
+- **THEN** the object SHALL be created using `review` without prompting

--- a/openspec/changes/issue-173-object-templates/specs/system-property-registry/spec.md
+++ b/openspec/changes/issue-173-object-templates/specs/system-property-registry/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: System property registry defines all system-managed properties
+
+The core package SHALL maintain a registry of system properties as a package-level slice. Each entry SHALL declare a property name, type, and immutability. Entries with `type: relation` SHALL additionally declare `Target` and `Multiple` fields. The registry SHALL define properties in display order: `name`, `description`, `created_at`, `updated_at`, `tags`. Properties with `Immutable: true` are auto-managed and SHALL NOT be overridden by templates or user input during creation. Properties with `Immutable: false` are user-authored and MAY be overridden.
+
+#### Scenario: Registry contains all system properties with immutability
+
+- **WHEN** the system property registry is queried
+- **THEN** it SHALL contain entries for `name` (text, mutable), `description` (text, mutable), `created_at` (datetime, immutable), `updated_at` (datetime, immutable), and `tags` (relation, target: tag, multiple: true, mutable) in that order
+
+## ADDED Requirements
+
+### Requirement: IsImmutableSystemProperty identifies auto-managed properties
+
+The `IsImmutableSystemProperty(name)` function SHALL return `true` for any system property with `Immutable: true` in the registry (`created_at`, `updated_at`), and `false` for all other names (including mutable system properties and non-system properties).
+
+#### Scenario: Immutable system property created_at
+
+- **WHEN** `IsImmutableSystemProperty("created_at")` is called
+- **THEN** it SHALL return `true`
+
+#### Scenario: Immutable system property updated_at
+
+- **WHEN** `IsImmutableSystemProperty("updated_at")` is called
+- **THEN** it SHALL return `true`
+
+#### Scenario: Mutable system property name
+
+- **WHEN** `IsImmutableSystemProperty("name")` is called
+- **THEN** it SHALL return `false`
+
+#### Scenario: Mutable system property description
+
+- **WHEN** `IsImmutableSystemProperty("description")` is called
+- **THEN** it SHALL return `false`
+
+#### Scenario: Mutable system property tags
+
+- **WHEN** `IsImmutableSystemProperty("tags")` is called
+- **THEN** it SHALL return `false`
+
+#### Scenario: Non-system property
+
+- **WHEN** `IsImmutableSystemProperty("title")` is called
+- **THEN** it SHALL return `false`

--- a/openspec/changes/issue-173-object-templates/tasks.md
+++ b/openspec/changes/issue-173-object-templates/tasks.md
@@ -1,0 +1,41 @@
+## 1. SystemProperty: Add Immutable field
+
+- [x] 1.1 Write BDD scenarios for system property immutability (registry contains immutable flags, IsImmutableSystemProperty behavior)
+- [x] 1.2 Implement step definitions for immutability scenarios
+- [x] 1.3 Add `Immutable bool` field to `SystemProperty` struct, set `created_at` and `updated_at` to `Immutable: true`
+- [x] 1.4 Add `IsImmutableSystemProperty(name)` function
+- [x] 1.5 Add unit tests for `IsImmutableSystemProperty` edge cases
+
+## 2. Core: Template path helpers
+
+- [x] 2.1 Add `TemplatesDir()`, `TypeTemplatesDir(typeName)`, and `TemplatePath(typeName, templateName)` methods to `Vault`
+- [x] 2.2 Add unit tests for template path helpers
+
+## 3. Core: ListTemplates
+
+- [x] 3.1 Write BDD scenarios for template discovery (multiple templates, single template, no directory, empty directory)
+- [x] 3.2 Implement step definitions for ListTemplates scenarios
+- [x] 3.3 Implement `ListTemplates(typeName)` method on `Vault`
+- [x] 3.4 Add unit tests for ListTemplates edge cases (non-.md files ignored, nested directories ignored)
+
+## 4. Core: LoadTemplate
+
+- [x] 4.1 Write BDD scenarios for template loading (frontmatter + body, body only, frontmatter only, not found)
+- [x] 4.2 Implement step definitions for LoadTemplate scenarios
+- [x] 4.3 Implement `LoadTemplate(typeName, templateName)` method on `Vault`
+
+## 5. Core: NewObject template application
+
+- [x] 5.1 Write BDD scenarios for template application (apply template, override schema default, immutable system props ignored, mutable system props applied, unknown props ignored, no template)
+- [x] 5.2 Implement step definitions for NewObject template scenarios
+- [x] 5.3 Extend `NewObject` signature to accept `templateName` parameter
+- [x] 5.4 Implement template loading and property merge logic in `NewObject`
+- [x] 5.5 Update all existing `NewObject` call sites to pass empty `templateName`
+
+## 6. CLI: Template flag and selection
+
+- [x] 6.1 Add `-t` / `--template` flag to `tmd object create` command
+- [x] 6.2 Implement auto-apply logic for single template
+- [x] 6.3 Implement interactive template selection for multiple templates
+- [x] 6.4 Pass selected template name to `NewObject`
+- [x] 6.5 Add unit tests for CLI template flag parsing

--- a/tui/app_test.go
+++ b/tui/app_test.go
@@ -688,7 +688,7 @@ func setupTestModelWithVault(t *testing.T) (model, *core.Object) {
 	}
 	t.Cleanup(func() { v.Close() })
 
-	obj, err := v.NewObject("book", "test-save")
+	obj, err := v.NewObject("book", "test-save", "")
 	if err != nil {
 		t.Fatalf("NewObject() error = %v", err)
 	}

--- a/websites/docs/src/content/docs/concepts/data-model.md
+++ b/websites/docs/src/content/docs/concepts/data-model.md
@@ -17,13 +17,17 @@ All objects have five system properties managed by TypeMD:
 
 | Property | Description |
 |----------|-------------|
-| `name` | Display name, auto-populated from the slug on creation |
-| `description` | Optional single-line summary for list displays and search results |
-| `created_at` | Creation timestamp in RFC 3339 format (set once, never modified) |
-| `updated_at` | Last-modified timestamp in RFC 3339 format (updated on every save) |
-| `tags` | Array of tag references (relation to the built-in `tag` type, multiple) |
+| Property | Description | Mutable |
+|----------|-------------|---------|
+| `name` | Display name, auto-populated from the slug on creation | User-authored |
+| `description` | Optional single-line summary for list displays and search results | User-authored |
+| `created_at` | Creation timestamp in RFC 3339 format (set once, never modified) | Auto-managed |
+| `updated_at` | Last-modified timestamp in RFC 3339 format (updated on every save) | Auto-managed |
+| `tags` | Array of tag references (relation to the built-in `tag` type, multiple) | User-authored |
 
 System properties always appear first in frontmatter in the order above, followed by schema-defined properties. These names are reserved and cannot be used in type schemas or shared properties.
+
+**User-authored** properties (`name`, `description`, `tags`) can be overridden by object templates. **Auto-managed** properties (`created_at`, `updated_at`) cannot be overridden — they always reflect the actual creation and modification times.
 
 ```
 vault/
@@ -33,6 +37,9 @@ vault/
 │   │   └── person.yaml     # example: you create this
 │   ├── index.db            # SQLite index (auto-updated)
 │   └── tui-state.yaml      # TUI session state (auto-saved)
+├── templates/              # object templates by type (optional)
+│   └── book/
+│       └── review.md       # default frontmatter + body for new objects
 └── objects/
     ├── book/
     │   └── golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz.md
@@ -41,6 +48,23 @@ vault/
 ```
 
 Only the `tag` type is built-in (it backs the `tags` system property). The built-in `tag` type includes a plural form ("tags") for grammatically correct display in group headers and has `unique: true` to enforce name uniqueness. All other types must be defined via `.typemd/types/*.yaml` files.
+
+### Object templates
+
+Each type can define one or more templates at `templates/<type>/<name>.md`. Templates are regular Markdown files (frontmatter + body) that provide default content when creating objects.
+
+```bash
+# Single template — auto-applied
+tmd object create book clean-code
+
+# Explicit template selection
+tmd object create book clean-code -t review
+
+# Multiple templates, no flag — interactive selection
+tmd object create book clean-code
+```
+
+Template frontmatter properties override schema defaults. Template body becomes the initial object body. Auto-managed system properties (`created_at`, `updated_at`) in templates are ignored.
 
 ### Unique constraint
 

--- a/websites/docs/src/content/docs/concepts/overview.md
+++ b/websites/docs/src/content/docs/concepts/overview.md
@@ -9,7 +9,7 @@ TypeMD uses a small set of core concepts to organize your knowledge. This page g
 
 ## Vault
 
-A Vault is a directory managed by TypeMD. It contains a `.typemd/` configuration folder and an `objects/` folder for your content. Each Vault is self-contained — you can move, copy, or version-control it like any folder.
+A Vault is a directory managed by TypeMD. It contains a `.typemd/` configuration folder, an `objects/` folder for your content, and an optional `templates/` folder for object templates. Each Vault is self-contained — you can move, copy, or version-control it like any folder.
 
 ## Object
 

--- a/websites/docs/src/content/docs/concepts/types.md
+++ b/websites/docs/src/content/docs/concepts/types.md
@@ -68,6 +68,23 @@ tags:
 
 During sync, TypeMD resolves name-based references to their full IDs and auto-creates missing tags.
 
+## Object templates
+
+Each Type can have one or more object templates stored at `templates/<type>/<name>.md`. Templates are regular Markdown files with optional frontmatter and body content that provide defaults when creating new Objects.
+
+```bash
+# If book has one template, it auto-applies
+tmd object create book clean-code
+
+# Specify a template explicitly
+tmd object create book clean-code -t review
+
+# If multiple templates exist, you'll be prompted to choose
+tmd object create book clean-code
+```
+
+Template frontmatter properties override the schema's default values. The template body becomes the initial body of the new Object. Auto-managed system properties (`created_at`, `updated_at`) in templates are ignored — they always reflect the actual creation time.
+
 ## Types vs. tags
 
 Tags categorize Objects across Types — a `book` and a `note` can share the same tag. Types define structure — a `book` always has title, status, and rating. Use Types for structural consistency; use tags for cross-cutting categorization.


### PR DESCRIPTION
## Summary

- Add `templates/<type>/` directory convention for per-type object templates (Markdown files with frontmatter + body)
- `tmd object create` auto-applies single template, interactively selects from multiple, or accepts `-t <name>` flag
- Template frontmatter overrides schema defaults; template body becomes initial object content
- Add `Immutable` field to `SystemProperty` to distinguish user-authored (`name`, `description`, `tags`) vs auto-managed (`created_at`, `updated_at`) properties — templates can only override user-authored system properties
- Placeholder/variable substitution deferred to a separate issue

## Issue

Closes #173

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [x] Manual: `tmd object create book -t review` applies the review template with pre-filled frontmatter and body
- [x] Manual: `tmd object create book` with multiple templates prompts for selection
- [x] Manual: `tmd object create book` with single template auto-applies it
- [x] Manual: verify `created_at`/`updated_at` in template are ignored (immutable system properties)