### PR TITLE
feat(core): enhance object create with vault config and slug conversion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,8 @@ graph LR
 | `doctor.go` | Doctor health check: RunDoctor orchestrator, DoctorReport, issue categories |
 | `doctor_orphan.go` | OrphanDir scanning for objects/ and templates/ without type schemas |
 | `starters.go` | Embedded starter type templates (idea/note/book) + StarterTypes() + Vault.WriteStarterTypes() |
+| `vault_config.go` | VaultConfig struct + YAML loading + WriteConfig + Vault.DefaultType() accessor |
+| `slugify.go` | Slugify() function for converting natural-language names to valid slugs |
 
 ### TUI Architecture
 
@@ -147,13 +149,14 @@ The right panel automatically follows the sidebar cursor: moving to an object sh
 ## Data Model
 
 - Objects identified by `type/<slug>-<ulid>` (e.g. `book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz`)
-- All objects have system properties managed by typemd: `name` (auto-populated from slug, or from name template if defined), `description` (optional, user-authored), `created_at` (set on creation, immutable), `updated_at` (updated on save, immutable), `tags` (relation to built-in `tag` type, multiple). These appear first in frontmatter in that order. System properties are either **user-authored** (`name`, `description`, `tags` — can be overridden by templates) or **auto-managed** (`created_at`, `updated_at` — cannot be overridden).
+- All objects have system properties managed by typemd: `name` (preserves original input on creation; auto-populated from slug for pre-slugified names, or from name template if defined), `description` (optional, user-authored), `created_at` (set on creation, immutable), `updated_at` (updated on save, immutable), `tags` (relation to built-in `tag` type, multiple). These appear first in frontmatter in that order. System properties are either **user-authored** (`name`, `description`, `tags` — can be overridden by templates) or **auto-managed** (`created_at`, `updated_at` — cannot be overridden).
 - Type schemas: `.typemd/types/*.yaml` (cannot define properties named `description`, `created_at`, `updated_at`, or `tags` — they're reserved system properties; `name` can appear in `properties` with only a `template` field for auto-generated names). Type schemas support optional `plural` (for display in collection contexts) and `unique` (to enforce name uniqueness) fields.
 - Shared properties: `.typemd/properties.yaml` (optional, defines reusable property definitions referenced via `use` in type schemas)
 - Relations defined as properties in type schemas
 - Wiki-links: `[[type/name-ulid]]` syntax in markdown body, with backlink tracking
 - SQLite index: `.typemd/index.db`
 - TUI session state: `.typemd/tui-state.yaml` (persisted on quit, restored on launch; stores `selected_object_id` or `selected_type_name`, expanded groups, scroll offset, panel widths, and props visibility)
+- Vault config: `.typemd/config.yaml` (optional, interface-layer namespacing; `cli.default_type` sets the default type for `tmd object create`)
 - Starter type templates: `core/starters/*.yaml` (embedded in binary via `//go:embed`; offered during `tmd init` as opt-in type schemas — idea, note, book)
 - Object templates: `templates/<type>/<name>.md` (optional, Markdown files with frontmatter property overrides and body content applied during `tmd object create`; single template auto-applies, multiple templates prompt for selection or use `-t` flag)
 - Object files: `objects/<type>/<name>.md`

--- a/README.md
+++ b/README.md
@@ -94,12 +94,16 @@ tmd --vault /path/to/vault
 # Open TUI in read-only mode (editing disabled)
 tmd --readonly
 
-# Create a new object (ULID is appended automatically)
-tmd object create book clean-code
+# Create a new object (names are auto-slugified, ULID appended)
+tmd object create book "Clean Code"
 # → Created book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz
 
-# Create with object template (auto-applied if only one exists)
-tmd object create book clean-code -t review
+# Use default type from config (omit type argument)
+tmd object create "Some Thought"
+# → Created idea/some-thought-01jqr3k5mpbvn8e0f2g7h9txyz
+
+# Create with object template
+tmd object create book "Clean Code" -t review
 # → Created book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz (with review template)
 
 # Create with name template (name auto-generated if type defines a template)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -88,12 +88,16 @@ tmd
 # 開啟 TUI（指定 vault 路徑）
 tmd --vault /path/to/vault
 
-# 建立新的 Object（ULID 會自動附加）
-tmd object create book clean-code
+# 建立新的 Object（名稱自動轉為 slug，ULID 自動附加）
+tmd object create book "Clean Code"
 # → Created book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz
 
+# 使用 config 中的預設 type（省略 type 參數）
+tmd object create "Some Thought"
+# → Created idea/some-thought-01jqr3k5mpbvn8e0f2g7h9txyz
+
 # 建立 Object 時套用範本
-tmd object create book clean-code -t review
+tmd object create book "Clean Code" -t review
 # → Created book/clean-code-01jqr3k5mpbvn8e0f2g7h9txyz（套用 review 範本）
 
 # 顯示 Object 詳情（支援前綴匹配，不需要輸入完整 ULID）

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,28 +4,40 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
 )
 
-var templateFlag string
+var (
+	templateFlag string
+	typeFlag     string
+)
 
 var createCmd = &cobra.Command{
-	Use:   "create <type> [name]",
+	Use:   "create [type] [name]",
 	Short: "Create a new object from a type schema",
 	Long: `Create a new object file (Markdown + YAML frontmatter) based on the type schema.
 A ULID is automatically appended to the filename for uniqueness.
 If the type has a name template, the name argument is optional.
 If the type has templates, they are applied automatically (single) or via selection (multiple).
 
+The type argument can be omitted if --type flag is set or cli.default_type is
+configured in .typemd/config.yaml. Names are automatically converted to slugs
+(e.g., "Some Thought" becomes "some-thought" in the filename).
+
+When a single argument matches a known type name, it is treated as the type.
+To use a name that collides with a type name, use the --type flag explicitly.
+
 Examples:
-  tmd object create book clean-code
-  tmd object create book clean-code -t review
-  tmd object create person robert-martin
-  tmd object create journal`,
-	Args: cobra.RangeArgs(1, 2),
+  tmd object create book "Clean Code"
+  tmd object create book "Clean Code" -t review
+  tmd object create --type idea "Some Thought"
+  tmd object create "Some Thought"              # uses default type from config
+  tmd object create book`,
+	Args: cobra.RangeArgs(0, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		vault, err := openVault(vaultPath, reindex)
 		if err != nil {
@@ -33,10 +45,9 @@ Examples:
 		}
 		defer vault.Close()
 
-		typeName := args[0]
-		name := ""
-		if len(args) > 1 {
-			name = args[1]
+		typeName, name, err := resolveTypeAndName(args, typeFlag, vault.DefaultType(), vault.ListTypes)
+		if err != nil {
+			return err
 		}
 
 		// Resolve template
@@ -69,6 +80,50 @@ Examples:
 	},
 }
 
+// resolveTypeAndName determines the type and name from positional args,
+// the --type flag, and the default type from config. listTypes is called
+// lazily only when needed to check if an argument is a known type.
+func resolveTypeAndName(args []string, typeFlag, defaultType string, listTypes func() []string) (typeName, name string, err error) {
+	// If --type flag is set, all positional args are the name
+	if typeFlag != "" {
+		typeName = typeFlag
+		if len(args) > 0 {
+			name = strings.Join(args, " ")
+		}
+		return typeName, name, nil
+	}
+
+	switch len(args) {
+	case 0:
+		// No args: type from config default
+		if defaultType == "" {
+			return "", "", fmt.Errorf("type is required: provide as argument, use --type flag, or set cli.default_type in .typemd/config.yaml")
+		}
+		typeName = defaultType
+	case 1:
+		// 1 arg: check if it's a known type
+		if isKnownType(args[0], listTypes()) {
+			typeName = args[0]
+		} else if defaultType != "" {
+			// Not a type → treat as name with default type
+			typeName = defaultType
+			name = args[0]
+		} else {
+			return "", "", fmt.Errorf("unknown type %q (no default type configured)", args[0])
+		}
+	case 2:
+		// 2 args: first is type, second is name (backward compatible)
+		typeName = args[0]
+		name = args[1]
+	}
+
+	return typeName, name, nil
+}
+
+func isKnownType(name string, knownTypes []string) bool {
+	return slices.Contains(knownTypes, name)
+}
+
 func promptTemplateSelection(templates []string) (string, error) {
 	fmt.Println("Multiple templates available:")
 	for i, name := range templates {
@@ -90,5 +145,6 @@ func promptTemplateSelection(templates []string) (string, error) {
 
 func init() {
 	createCmd.Flags().StringVarP(&templateFlag, "template", "t", "", "template name to use")
+	createCmd.Flags().StringVar(&typeFlag, "type", "", "object type (overrides config default)")
 	objectCmd.AddCommand(createCmd)
 }

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -149,3 +149,104 @@ func TestCreateCmd_InvalidTemplateFlag(t *testing.T) {
 	}
 }
 
+func TestResolveTypeAndName(t *testing.T) {
+	knownTypes := []string{"book", "idea", "note", "tag"}
+
+	tests := []struct {
+		name        string
+		args        []string
+		typeFlag    string
+		defaultType string
+		wantType    string
+		wantName    string
+		wantErr     bool
+	}{
+		{
+			name:     "two args: type and name (backward compatible)",
+			args:     []string{"book", "Clean Code"},
+			wantType: "book",
+			wantName: "Clean Code",
+		},
+		{
+			name:     "one arg: known type",
+			args:     []string{"book"},
+			wantType: "book",
+			wantName: "",
+		},
+		{
+			name:        "one arg: not a type, has default",
+			args:        []string{"Some Thought"},
+			defaultType: "idea",
+			wantType:    "idea",
+			wantName:    "Some Thought",
+		},
+		{
+			name:    "one arg: not a type, no default",
+			args:    []string{"Some Thought"},
+			wantErr: true,
+		},
+		{
+			name:        "zero args: has default type",
+			args:        []string{},
+			defaultType: "idea",
+			wantType:    "idea",
+			wantName:    "",
+		},
+		{
+			name:    "zero args: no default type",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:     "type flag: with name",
+			args:     []string{"Meeting Notes"},
+			typeFlag: "note",
+			wantType: "note",
+			wantName: "Meeting Notes",
+		},
+		{
+			name:     "type flag: no name",
+			args:     []string{},
+			typeFlag: "idea",
+			wantType: "idea",
+			wantName: "",
+		},
+		{
+			name:        "type flag overrides config default",
+			args:        []string{"Meeting Notes"},
+			typeFlag:    "note",
+			defaultType: "idea",
+			wantType:    "note",
+			wantName:    "Meeting Notes",
+		},
+		{
+			name:     "type flag: multiple name args joined",
+			args:     []string{"Some", "Thought"},
+			typeFlag: "idea",
+			wantType: "idea",
+			wantName: "Some Thought",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotType, gotName, err := resolveTypeAndName(tt.args, tt.typeFlag, tt.defaultType, func() []string { return knownTypes })
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotType != tt.wantType {
+				t.Errorf("type = %q, want %q", gotType, tt.wantType)
+			}
+			if gotName != tt.wantName {
+				t.Errorf("name = %q, want %q", gotName, tt.wantName)
+			}
+		})
+	}
+}
+

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"slices"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/spf13/cobra"
+	"github.com/typemd/typemd/core"
 )
 
 var noStarters bool
@@ -48,6 +50,16 @@ var initCmd = &cobra.Command{
 			return err
 		}
 
+		// Write config.yaml with default_type if a quick-suitable type was selected
+		if defaultType := resolveDefaultType(names); defaultType != "" {
+			cfg := &core.VaultConfig{
+				CLI: core.CLIConfig{DefaultType: defaultType},
+			}
+			if err := vault.WriteConfig(cfg); err != nil {
+				return fmt.Errorf("write config: %w", err)
+			}
+		}
+
 		fmt.Println()
 		fmt.Printf("Created %d starter type(s):\n", len(selected))
 		for _, item := range selected {
@@ -56,6 +68,18 @@ var initCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+// resolveDefaultType picks the best default type from selected starter names.
+// Returns "idea" if selected, then "note" as fallback, or empty if neither.
+func resolveDefaultType(names []string) string {
+	if slices.Contains(names, "idea") {
+		return "idea"
+	}
+	if slices.Contains(names, "note") {
+		return "note"
+	}
+	return ""
 }
 
 func init() {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -13,3 +13,26 @@ func TestInitCmd_NoStartersFlag(t *testing.T) {
 		t.Errorf("expected default false, got %q", f.DefValue)
 	}
 }
+
+func TestResolveDefaultType(t *testing.T) {
+	tests := []struct {
+		name     string
+		names    []string
+		expected string
+	}{
+		{"idea selected", []string{"idea", "book"}, "idea"},
+		{"note only", []string{"note", "book"}, "note"},
+		{"idea and note — idea wins", []string{"note", "idea"}, "idea"},
+		{"book only — no default", []string{"book"}, ""},
+		{"empty — no default", []string{}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveDefaultType(tt.names)
+			if got != tt.expected {
+				t.Errorf("resolveDefaultType(%v) = %q, want %q", tt.names, got, tt.expected)
+			}
+		})
+	}
+}

--- a/core/bdd_steps_slug_integration_test.go
+++ b/core/bdd_steps_slug_integration_test.go
@@ -1,0 +1,38 @@
+package core
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cucumber/godog"
+)
+
+func (dc *domainContext) theCurrentObjectIDShouldContain(substr string) error {
+	if dc.currentObject == nil {
+		return fmt.Errorf("no current object")
+	}
+	if !strings.Contains(dc.currentObject.ID, substr) {
+		return fmt.Errorf("expected object ID %q to contain %q", dc.currentObject.ID, substr)
+	}
+	return nil
+}
+
+func (dc *domainContext) theCurrentObjectNamePropertyShouldBe(expected string) error {
+	if dc.currentObject == nil {
+		return fmt.Errorf("no current object")
+	}
+	name, ok := dc.currentObject.Properties[NameProperty]
+	if !ok {
+		return fmt.Errorf("name property not found")
+	}
+	got := fmt.Sprintf("%v", name)
+	if got != expected {
+		return fmt.Errorf("expected name property %q, got %q", expected, got)
+	}
+	return nil
+}
+
+func initSlugIntegrationSteps(ctx *godog.ScenarioContext, dc *domainContext) {
+	ctx.Step(`^the current object ID should contain "([^"]*)"$`, dc.theCurrentObjectIDShouldContain)
+	ctx.Step(`^the current object name property should be "([^"]*)"$`, dc.theCurrentObjectNamePropertyShouldBe)
+}

--- a/core/bdd_steps_slug_test.go
+++ b/core/bdd_steps_slug_test.go
@@ -1,0 +1,28 @@
+package core
+
+import (
+	"fmt"
+
+	"github.com/cucumber/godog"
+)
+
+type slugContext struct {
+	result string
+}
+
+func (sc *slugContext) iSlugify(input string) {
+	sc.result = Slugify(input)
+}
+
+func (sc *slugContext) theSlugShouldBe(expected string) error {
+	if sc.result != expected {
+		return fmt.Errorf("expected slug %q, got %q", expected, sc.result)
+	}
+	return nil
+}
+
+func initSlugSteps(ctx *godog.ScenarioContext, _ *domainContext) {
+	sc := &slugContext{}
+	ctx.Step(`^I slugify "([^"]*)"$`, sc.iSlugify)
+	ctx.Step(`^the slug should be "([^"]*)"$`, sc.theSlugShouldBe)
+}

--- a/core/bdd_steps_vault_config_test.go
+++ b/core/bdd_steps_vault_config_test.go
@@ -1,0 +1,27 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cucumber/godog"
+)
+
+func (dc *domainContext) aConfigFileWithContent(content *godog.DocString) {
+	path := filepath.Join(dc.vault.Dir(), configFileName)
+	os.WriteFile(path, []byte(content.Content), 0644)
+}
+
+func (dc *domainContext) theDefaultTypeShouldBe(expected string) error {
+	got := dc.vault.DefaultType()
+	if got != expected {
+		return fmt.Errorf("expected default type %q, got %q", expected, got)
+	}
+	return nil
+}
+
+func initVaultConfigSteps(ctx *godog.ScenarioContext, dc *domainContext) {
+	ctx.Step(`^a config file with content:$`, dc.aConfigFileWithContent)
+	ctx.Step(`^the default type should be "([^"]*)"$`, dc.theDefaultTypeShouldBe)
+}

--- a/core/bdd_test.go
+++ b/core/bdd_test.go
@@ -152,6 +152,9 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	initTypeCrudSteps(ctx, dc)
 	initDoctorSteps(ctx, dc)
 	initStarterSteps(ctx, dc)
+	initVaultConfigSteps(ctx, dc)
+	initSlugSteps(ctx, dc)
+	initSlugIntegrationSteps(ctx, dc)
 }
 
 func TestFeatures(t *testing.T) {

--- a/core/features/slug_conversion.feature
+++ b/core/features/slug_conversion.feature
@@ -1,0 +1,44 @@
+Feature: Slug conversion
+  As a user
+  I want to enter natural-language names
+  So that they are automatically converted to valid slugs
+
+  Scenario: Simple name with spaces
+    When I slugify "Some Thought"
+    Then the slug should be "some-thought"
+
+  Scenario: Name with mixed case
+    When I slugify "Clean Code"
+    Then the slug should be "clean-code"
+
+  Scenario: Name with underscores
+    When I slugify "my_great_idea"
+    Then the slug should be "my-great-idea"
+
+  Scenario: Name with special characters
+    When I slugify "What's the plan?"
+    Then the slug should be "whats-the-plan"
+
+  Scenario: Name with consecutive spaces
+    When I slugify "too   many   spaces"
+    Then the slug should be "too-many-spaces"
+
+  Scenario: Name with leading and trailing whitespace
+    When I slugify "  padded name  "
+    Then the slug should be "padded-name"
+
+  Scenario: Already slugified input is idempotent
+    When I slugify "clean-code"
+    Then the slug should be "clean-code"
+
+  Scenario: Name with numbers
+    When I slugify "Chapter 3 Notes"
+    Then the slug should be "chapter-3-notes"
+
+  Scenario: Non-ASCII letters are preserved
+    When I slugify "café latte"
+    Then the slug should be "café-latte"
+
+  Scenario: CJK characters are preserved
+    When I slugify "我的日記"
+    Then the slug should be "我的日記"

--- a/core/features/slug_integration.feature
+++ b/core/features/slug_integration.feature
@@ -1,0 +1,25 @@
+Feature: Object creation with slug conversion
+  As a user
+  I want to create objects with natural-language names
+  So that filenames are valid slugs while display names preserve my input
+
+  Scenario: Natural-language name is slugified for filename
+    Given a vault is ready
+    When I create a "book" object named "Some Great Thought"
+    Then no error should occur
+    And the current object ID should contain "some-great-thought"
+    And the current object name property should be "Some Great Thought"
+
+  Scenario: Pre-slugified name passes through unchanged
+    Given a vault is ready
+    When I create a "book" object named "already-slugified"
+    Then no error should occur
+    And the current object ID should contain "already-slugified"
+    And the current object name property should be "already-slugified"
+
+  Scenario: Name with special characters is slugified
+    Given a vault is ready
+    When I create a "book" object named "What's Next?"
+    Then no error should occur
+    And the current object ID should contain "whats-next"
+    And the current object name property should be "What's Next?"

--- a/core/features/vault_config.feature
+++ b/core/features/vault_config.feature
@@ -1,0 +1,51 @@
+Feature: Vault configuration
+  As a user
+  I want to configure vault-level settings
+  So that CLI commands can use sensible defaults
+
+  Scenario: Config file with valid content
+    Given a vault is initialized
+    And a config file with content:
+      """
+      cli:
+        default_type: idea
+      """
+    When I open the vault
+    Then no error should occur
+    And the default type should be "idea"
+
+  Scenario: Config file does not exist
+    Given a vault is initialized
+    When I open the vault
+    Then no error should occur
+    And the default type should be ""
+
+  Scenario: Config file is empty
+    Given a vault is initialized
+    And a config file with content:
+      """
+      """
+    When I open the vault
+    Then no error should occur
+    And the default type should be ""
+
+  Scenario: Config file has invalid YAML
+    Given a vault is initialized
+    And a config file with content:
+      """
+      [invalid: yaml: content
+      """
+    When I open the vault
+    Then an error should occur
+
+  Scenario: Unknown keys are ignored
+    Given a vault is initialized
+    And a config file with content:
+      """
+      unknown_key: some_value
+      cli:
+        default_type: note
+      """
+    When I open the vault
+    Then no error should occur
+    And the default type should be "note"

--- a/core/object_service.go
+++ b/core/object_service.go
@@ -64,8 +64,11 @@ func (s *ObjectService) Create(typeName, filename, templateName string) (*Object
 		}
 	}
 
-	// Generate ObjectID with ULID suffix
-	slug := filename
+	// Generate ObjectID with ULID suffix (slugify the filename for the ID)
+	slug := Slugify(filename)
+	if slug == "" {
+		return nil, fmt.Errorf("name %q must contain at least one alphanumeric character", filename)
+	}
 	objID, err := NewObjectID(typeName, slug)
 	if err != nil {
 		return nil, err
@@ -77,8 +80,9 @@ func (s *ObjectService) Create(typeName, filename, templateName string) (*Object
 	}
 
 	// Generate initial properties from schema defaults
+	// Name property preserves original input (not the slugified version)
 	props := make(map[string]any)
-	props[NameProperty] = slug
+	props[NameProperty] = filename
 	nowStr := now.Format(time.RFC3339)
 	props[CreatedAtProperty] = nowStr
 	props[UpdatedAtProperty] = nowStr

--- a/core/slugify.go
+++ b/core/slugify.go
@@ -1,0 +1,41 @@
+package core
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var multiHyphenPattern = regexp.MustCompile(`-{2,}`)
+
+// Slugify converts a natural-language name to a valid slug.
+// It lowercases, replaces spaces/underscores with hyphens, removes non-alphanumeric
+// characters (except hyphens), collapses consecutive hyphens, and trims.
+func Slugify(name string) string {
+	// Lowercase
+	s := strings.ToLower(name)
+
+	// Replace spaces and underscores with hyphens
+	s = strings.Map(func(r rune) rune {
+		switch {
+		case r == ' ' || r == '_':
+			return '-'
+		case unicode.IsLetter(r):
+			return r
+		case unicode.IsDigit(r):
+			return r
+		case r == '-':
+			return r
+		default:
+			return -1 // remove
+		}
+	}, s)
+
+	// Collapse consecutive hyphens
+	s = multiHyphenPattern.ReplaceAllString(s, "-")
+
+	// Trim leading/trailing hyphens
+	s = strings.Trim(s, "-")
+
+	return s
+}

--- a/core/slugify_test.go
+++ b/core/slugify_test.go
@@ -1,0 +1,37 @@
+package core
+
+import "testing"
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty string", "", ""},
+		{"simple spaces", "Some Thought", "some-thought"},
+		{"mixed case", "Clean Code", "clean-code"},
+		{"underscores", "my_great_idea", "my-great-idea"},
+		{"special characters", "What's the plan?", "whats-the-plan"},
+		{"consecutive spaces", "too   many   spaces", "too-many-spaces"},
+		{"leading trailing whitespace", "  padded name  ", "padded-name"},
+		{"idempotent", "clean-code", "clean-code"},
+		{"numbers preserved", "Chapter 3 Notes", "chapter-3-notes"},
+		{"non-ASCII letters preserved", "café latte", "café-latte"},
+		{"CJK characters preserved", "我的日記", "我的日記"},
+		{"only special chars", "!@#$%", ""},
+		{"consecutive hyphens", "a--b---c", "a-b-c"},
+		{"mixed separators", "hello_world foo-bar", "hello-world-foo-bar"},
+		{"trailing special chars", "hello!", "hello"},
+		{"leading special chars", "!hello", "hello"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Slugify(tt.input)
+			if got != tt.expected {
+				t.Errorf("Slugify(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/core/vault.go
+++ b/core/vault.go
@@ -23,6 +23,7 @@ type Vault struct {
 	Objects           *ObjectService
 	Queries           *QueryService
 	Events            *EventDispatcher
+	config            *VaultConfig
 	sharedProperties  []Property
 	sharedPropsMap    map[string]Property
 	sharedPropsLoaded bool
@@ -71,6 +72,20 @@ func (v *Vault) TemplatePath(typeName, templateName string) string {
 	return filepath.Join(v.TypeTemplatesDir(typeName), templateName+".md")
 }
 
+// ConfigPath returns the path to the vault config file.
+func (v *Vault) ConfigPath() string {
+	return filepath.Join(v.Dir(), configFileName)
+}
+
+// DefaultType returns the configured default type for CLI commands.
+// Returns an empty string if not configured.
+func (v *Vault) DefaultType() string {
+	if v.config == nil {
+		return ""
+	}
+	return v.config.CLI.DefaultType
+}
+
 // ObjectsDir returns the objects directory path.
 func (v *Vault) ObjectsDir() string {
 	return filepath.Join(v.Root, "objects")
@@ -105,6 +120,13 @@ func (v *Vault) Open() error {
 	v.Events = NewEventDispatcher()
 	v.Objects = NewObjectService(v.repo, v.index, v.Events)
 	v.Queries = NewQueryService(v.repo, v.index)
+	cfg, err := loadVaultConfig(v.Dir())
+	if err != nil {
+		v.closeInternal()
+		return fmt.Errorf("load config: %w", err)
+	}
+	v.config = cfg
+
 	v.projector = NewProjector(v.repo, v.index, func(slug string) (*Object, error) {
 		return v.Objects.Create(TagTypeName, slug, "")
 	})
@@ -141,6 +163,7 @@ func (v *Vault) closeInternal() {
 	v.Objects = nil
 	v.Queries = nil
 	v.Events = nil
+	v.config = nil
 }
 
 // Close closes the SQLite database connection.
@@ -156,6 +179,7 @@ func (v *Vault) Close() error {
 	v.Objects = nil
 	v.Queries = nil
 	v.Events = nil
+	v.config = nil
 	return err
 }
 

--- a/core/vault_config.go
+++ b/core/vault_config.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const configFileName = "config.yaml"
+
+// VaultConfig holds vault-level configuration loaded from .typemd/config.yaml.
+type VaultConfig struct {
+	CLI CLIConfig `yaml:"cli"`
+}
+
+// CLIConfig holds CLI-specific configuration.
+type CLIConfig struct {
+	DefaultType string `yaml:"default_type"`
+}
+
+// loadVaultConfig reads and parses the vault config file.
+// Returns a zero-value VaultConfig if the file does not exist or is empty.
+func loadVaultConfig(metaDir string) (*VaultConfig, error) {
+	path := filepath.Join(metaDir, configFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &VaultConfig{}, nil
+		}
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	var cfg VaultConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// WriteConfig writes a VaultConfig to the vault's config.yaml file
+// and updates the in-memory config.
+func (v *Vault) WriteConfig(cfg *VaultConfig) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(v.Dir(), configFileName), data, 0644); err != nil {
+		return err
+	}
+	v.config = cfg
+	return nil
+}

--- a/core/vault_config_test.go
+++ b/core/vault_config_test.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadVaultConfig_UnknownKeysIgnored(t *testing.T) {
+	dir := t.TempDir()
+	content := "unknown_key: value\ncli:\n  default_type: idea\n"
+	os.WriteFile(filepath.Join(dir, configFileName), []byte(content), 0644)
+
+	cfg, err := loadVaultConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CLI.DefaultType != "idea" {
+		t.Errorf("expected default_type=idea, got %q", cfg.CLI.DefaultType)
+	}
+}
+
+func TestLoadVaultConfig_PartialConfig_OnlyCLI(t *testing.T) {
+	dir := t.TempDir()
+	content := "cli:\n  default_type: note\n"
+	os.WriteFile(filepath.Join(dir, configFileName), []byte(content), 0644)
+
+	cfg, err := loadVaultConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CLI.DefaultType != "note" {
+		t.Errorf("expected default_type=note, got %q", cfg.CLI.DefaultType)
+	}
+}
+
+func TestLoadVaultConfig_PartialConfig_CLIWithoutDefaultType(t *testing.T) {
+	dir := t.TempDir()
+	content := "cli:\n  other_field: value\n"
+	os.WriteFile(filepath.Join(dir, configFileName), []byte(content), 0644)
+
+	cfg, err := loadVaultConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CLI.DefaultType != "" {
+		t.Errorf("expected empty default_type, got %q", cfg.CLI.DefaultType)
+	}
+}
+
+func TestLoadVaultConfig_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg, err := loadVaultConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CLI.DefaultType != "" {
+		t.Errorf("expected empty default_type, got %q", cfg.CLI.DefaultType)
+	}
+}
+
+func TestLoadVaultConfig_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, configFileName), []byte(""), 0644)
+
+	cfg, err := loadVaultConfig(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.CLI.DefaultType != "" {
+		t.Errorf("expected empty default_type, got %q", cfg.CLI.DefaultType)
+	}
+}
+
+func TestLoadVaultConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, configFileName), []byte("[invalid: yaml: content"), 0644)
+
+	_, err := loadVaultConfig(dir)
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}

--- a/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-16

--- a/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/design.md
+++ b/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/design.md
@@ -1,0 +1,104 @@
+## Context
+
+`tmd object create <type> [name]` requires a type as the first positional argument. Users wanting quick capture must remember type names and format names as slugs. Issue #236 originally proposed a `tmd quick` command, but exploration revealed it would duplicate `tmd object create`. Instead, we enhance the existing command with a vault config default type and automatic slug conversion.
+
+Currently there is no vault-level configuration system. Settings are either file-based (type schemas, shared properties) or runtime-only. TUI session state (`.typemd/tui-state.yaml`) stores UI preferences but is TUI-specific.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow `tmd object create` to work without specifying a type (read from config)
+- Accept natural-language names and auto-convert to valid slugs
+- Introduce a vault config system that other features can build on
+- Maintain full backward compatibility
+
+**Non-Goals:**
+- AI-powered auto-fill (`--ai` flag) — future work
+- Migrating TUI preferences from `tui-state.yaml` to config — separate issue
+- Interactive name prompt via Bubble Tea when no name is given — deferred to keep scope small
+- Config validation or `tmd config` management commands
+
+## Decisions
+
+### 1. Vault config file at `.typemd/config.yaml`
+
+Config lives in the `.typemd/` directory alongside other vault metadata. Structure uses interface-layer namespacing:
+
+```yaml
+cli:
+  default_type: idea
+```
+
+**Rationale:** Grouping by interface (cli, tui, web, mcp) keeps concerns separated and avoids naming collisions. The file is optional — missing file means empty/default config.
+
+**Alternatives considered:**
+- Flat keys (`default_type: idea`) — doesn't scale, no namespace
+- Root-level `vault:` key — unnecessary nesting for now
+
+### 2. Config struct is minimal
+
+```go
+type VaultConfig struct {
+    CLI CLIConfig `yaml:"cli"`
+}
+
+type CLIConfig struct {
+    DefaultType string `yaml:"default_type"`
+}
+```
+
+Config is loaded during `Vault.Open()` and stored on the Vault struct. Missing file or missing keys result in zero values (no error). The struct can grow organically as new features need configuration.
+
+### 3. Slug conversion in core layer
+
+A `Slugify(name string)` function in `core/` handles conversion:
+- Lowercase
+- Replace spaces and underscores with hyphens
+- Remove non-alphanumeric characters (except hyphens)
+- Collapse consecutive hyphens
+- Trim leading/trailing hyphens
+
+Applied in `ObjectService.Create()` so all creation paths (CLI, TUI, MCP) benefit. The function is idempotent — already-slugified input passes through unchanged.
+
+**Rationale:** Core-layer conversion means every consumer gets consistent behavior. No risk of one path forgetting to slugify.
+
+**Alternatives considered:**
+- CLI-layer only — requires each consumer to remember to slugify
+- External library — unnecessary dependency for simple string transforms
+
+### 4. Name property preserves original input
+
+When `ObjectService.Create("idea", "Some Thought", "")` is called:
+- Slug for ObjectID/filename: `Slugify("Some Thought")` → `some-thought`
+- `name` property in frontmatter: `"Some Thought"` (original input)
+
+This means the display name can differ from the filename slug, which is already possible when users edit the `name` property after creation.
+
+**Rationale:** Users expect their input to appear as the display name, not a slugified version. The slug is an implementation detail of the file system.
+
+### 5. Type argument resolution with smart fallback
+
+The `tmd object create` command changes from `RangeArgs(1, 2)` to `RangeArgs(0, 2)`.
+
+Resolution logic for positional arguments:
+- **0 args**: type from `--type` flag or config `cli.default_type`; name empty (requires name template on schema)
+- **1 arg**: attempt to resolve as type name → if valid type, treat as type (backward compatible); if not a valid type AND default type is available (flag or config), treat as name
+- **2 args**: first is type, second is name (current behavior, unchanged)
+
+**Rationale:** This preserves full backward compatibility while enabling the new `tmd object create "Some Thought"` pattern when a default type is configured.
+
+### 6. `--type` flag without `-t` short form
+
+The `-t` short flag is already taken by `--template`. The new type override uses `--type` only (no short flag).
+
+```bash
+tmd object create --type note "Meeting Notes"
+```
+
+**Rationale:** Avoiding ambiguity. `--type` is expected to be used less frequently than `--template` since the config default covers the common case.
+
+## Risks / Trade-offs
+
+- **[Ambiguous 1-arg resolution]** → When 1 arg is given, the heuristic checks if it's a valid type. If a user mistypes a type name and has `cli.default_type` set, it would be treated as a name. Mitigation: this is a rare edge case, and the resulting object name would be clearly wrong, prompting the user to notice.
+- **[Config file conflicts]** → Multiple processes writing config simultaneously. Mitigation: config is read-only for now; no write path exists. Future config commands should handle this.
+- **[Slug collision]** → Different natural-language names could slugify to the same value (e.g., "Some Thought!" and "Some Thought"). Mitigation: ULID suffix ensures filename uniqueness regardless of slug collisions. Types with `unique: true` check the `name` property (original input), not the slug.

--- a/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/proposal.md
+++ b/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`tmd object create <type> <name>` requires users to provide both type and a slug-formatted name every time, creating too much friction for quick idea capture. Users need a lower-friction creation flow: omit type to use a configured default, and enter natural-language names that auto-convert to slugs.
+
+## What Changes
+
+- Add **vault config system** (`.typemd/config.yaml`) with interface-layer namespacing (`cli`, `tui`)
+- Make `tmd object create`'s **type argument optional** — falls back to `cli.default_type` from config
+- Add **automatic slug conversion** for names — spaces to hyphens, lowercasing, etc.
+- Add `--type` / `-t` flag to override the configured default type
+
+## Capabilities
+
+### New Capabilities
+- `vault-config`: Vault-level configuration file system (`.typemd/config.yaml`) with interface-layer namespacing (cli, tui). Initially implements `cli.default_type`.
+- `slug-conversion`: Automatic conversion of natural-language names to valid slug format (spaces → hyphens, lowercasing, etc.)
+
+### Modified Capabilities
+- `object-templates`: `tmd object create`'s type argument changes from required to optional; adds `-t` flag for type override
+
+## Impact
+
+- **core/**: New vault config loading logic, slug conversion utility
+- **cmd/**: Modify `create.go` args handling (type becomes optional), add `-t` flag
+- **File format**: New `.typemd/config.yaml`
+- **Backward compatibility**: Fully backward-compatible — behavior unchanged without config

--- a/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/specs/object-templates/spec.md
+++ b/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/specs/object-templates/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: CLI create command supports type flag
+
+The `tmd object create` command SHALL accept an optional `--type` flag to specify the object type. When `--type` is provided, all positional arguments are treated as the name. The `--type` flag SHALL NOT have a `-t` short form (reserved by `--template`).
+
+#### Scenario: Create with --type flag and name
+
+- **WHEN** `tmd object create --type note "Meeting Notes"` is executed
+- **THEN** the object SHALL be created with type `note` and name `"Meeting Notes"`
+
+#### Scenario: Create with --type flag and no name
+
+- **WHEN** `tmd object create --type idea` is executed
+- **AND** the `idea` type has a name template
+- **THEN** the object SHALL be created with the auto-generated name
+
+#### Scenario: Create with --type flag overriding config default
+
+- **WHEN** config has `cli.default_type: idea`
+- **AND** `tmd object create --type note "Meeting Notes"` is executed
+- **THEN** the object SHALL be created with type `note` (flag overrides config)
+
+### Requirement: CLI create command type argument is optional
+
+The `tmd object create` command SHALL accept 0 to 2 positional arguments. When the type is not provided as a positional argument, it SHALL be resolved from the `--type` flag or `cli.default_type` config.
+
+#### Scenario: Zero args with config default type and name template
+
+- **WHEN** `tmd object create` is executed with no arguments
+- **AND** config has `cli.default_type: idea`
+- **AND** the `idea` type has a name template
+- **THEN** the object SHALL be created with type `idea` and auto-generated name
+
+#### Scenario: Zero args without config or flag
+
+- **WHEN** `tmd object create` is executed with no arguments
+- **AND** no `--type` flag is provided
+- **AND** no `cli.default_type` is configured
+- **THEN** the command SHALL return an error indicating type is required
+
+#### Scenario: One arg resolved as type (backward compatible)
+
+- **WHEN** `tmd object create book` is executed
+- **AND** `book` is a valid type in the vault
+- **THEN** the object SHALL be created with type `book` (backward compatible behavior)
+
+#### Scenario: One arg resolved as name with config default
+
+- **WHEN** `tmd object create "Some Thought"` is executed
+- **AND** `"Some Thought"` is NOT a valid type in the vault
+- **AND** config has `cli.default_type: idea`
+- **THEN** the object SHALL be created with type `idea` and name `"Some Thought"`
+
+#### Scenario: One arg not a valid type and no default
+
+- **WHEN** `tmd object create "Some Thought"` is executed
+- **AND** `"Some Thought"` is NOT a valid type in the vault
+- **AND** no `cli.default_type` is configured and no `--type` flag provided
+- **THEN** the command SHALL return an error indicating unknown type
+
+#### Scenario: Two args (backward compatible)
+
+- **WHEN** `tmd object create book "Clean Code"` is executed
+- **THEN** the object SHALL be created with type `book` and name `"Clean Code"` (unchanged behavior)

--- a/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/specs/slug-conversion/spec.md
+++ b/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/specs/slug-conversion/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Slugify converts natural-language names to valid slugs
+
+The `Slugify(name string)` function SHALL convert a natural-language string to a valid slug suitable for filenames and ObjectIDs. The conversion SHALL:
+1. Convert to lowercase
+2. Replace spaces and underscores with hyphens
+3. Remove characters that are not alphanumeric or hyphens
+4. Collapse consecutive hyphens into a single hyphen
+5. Trim leading and trailing hyphens
+
+#### Scenario: Simple name with spaces
+
+- **WHEN** `Slugify("Some Thought")` is called
+- **THEN** it SHALL return `"some-thought"`
+
+#### Scenario: Name with mixed case
+
+- **WHEN** `Slugify("Clean Code")` is called
+- **THEN** it SHALL return `"clean-code"`
+
+#### Scenario: Name with underscores
+
+- **WHEN** `Slugify("my_great_idea")` is called
+- **THEN** it SHALL return `"my-great-idea"`
+
+#### Scenario: Name with special characters
+
+- **WHEN** `Slugify("What's the plan?")` is called
+- **THEN** it SHALL return `"whats-the-plan"`
+
+#### Scenario: Name with consecutive spaces
+
+- **WHEN** `Slugify("too   many   spaces")` is called
+- **THEN** it SHALL return `"too-many-spaces"`
+
+#### Scenario: Name with leading/trailing whitespace
+
+- **WHEN** `Slugify("  padded name  ")` is called
+- **THEN** it SHALL return `"padded-name"`
+
+#### Scenario: Already-slugified input is idempotent
+
+- **WHEN** `Slugify("clean-code")` is called
+- **THEN** it SHALL return `"clean-code"`
+
+#### Scenario: Empty string
+
+- **WHEN** `Slugify("")` is called
+- **THEN** it SHALL return `""`
+
+#### Scenario: Name with numbers
+
+- **WHEN** `Slugify("Chapter 3 Notes")` is called
+- **THEN** it SHALL return `"chapter-3-notes"`
+
+#### Scenario: Name with non-ASCII characters
+
+- **WHEN** `Slugify("café latte")` is called
+- **THEN** it SHALL return `"caf-latte"`
+
+### Requirement: ObjectService.Create applies slug conversion to filename
+
+`ObjectService.Create()` SHALL apply `Slugify()` to the filename parameter when generating the ObjectID. The original (pre-slugified) input SHALL be used as the `name` property value.
+
+#### Scenario: Natural-language name is slugified for filename
+
+- **WHEN** `ObjectService.Create("idea", "Some Great Thought", "")` is called
+- **THEN** the ObjectID filename SHALL contain `some-great-thought-<ULID>`
+- **AND** the `name` property SHALL be `"Some Great Thought"`
+
+#### Scenario: Pre-slugified name passes through unchanged
+
+- **WHEN** `ObjectService.Create("idea", "already-slugified", "")` is called
+- **THEN** the ObjectID filename SHALL contain `already-slugified-<ULID>`
+- **AND** the `name` property SHALL be `"already-slugified"`

--- a/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/specs/vault-config/spec.md
+++ b/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/specs/vault-config/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Vault loads config from `.typemd/config.yaml`
+
+The Vault SHALL load configuration from `.typemd/config.yaml` during `Open()`. The config file is optional — if the file does not exist or is empty, the Vault SHALL use zero-value defaults with no error.
+
+#### Scenario: Config file exists with valid content
+
+- **WHEN** `.typemd/config.yaml` contains `cli:\n  default_type: idea`
+- **THEN** the Vault SHALL load the config with `CLI.DefaultType` set to `"idea"`
+
+#### Scenario: Config file does not exist
+
+- **WHEN** `.typemd/config.yaml` does not exist
+- **THEN** the Vault SHALL use an empty config with all fields at zero values
+- **AND** no error SHALL be returned
+
+#### Scenario: Config file is empty
+
+- **WHEN** `.typemd/config.yaml` exists but is empty
+- **THEN** the Vault SHALL use an empty config with all fields at zero values
+- **AND** no error SHALL be returned
+
+#### Scenario: Config file has invalid YAML
+
+- **WHEN** `.typemd/config.yaml` contains invalid YAML syntax
+- **THEN** the Vault SHALL return an error during `Open()`
+
+### Requirement: Config struct uses interface-layer namespacing
+
+The `VaultConfig` struct SHALL organize settings under interface-layer keys: `cli`, `tui` (future). Each interface layer SHALL have its own sub-struct.
+
+#### Scenario: CLI config with default_type
+
+- **WHEN** config contains `cli:\n  default_type: note`
+- **THEN** `config.CLI.DefaultType` SHALL be `"note"`
+
+#### Scenario: Unknown top-level keys are ignored
+
+- **WHEN** config contains `unknown_key: value` alongside valid keys
+- **THEN** the Vault SHALL load successfully, ignoring the unknown key
+
+### Requirement: Vault exposes DefaultType accessor
+
+The Vault SHALL provide a `DefaultType()` method that returns the configured `cli.default_type` value. If no default type is configured, it SHALL return an empty string.
+
+#### Scenario: Default type is configured
+
+- **WHEN** config has `cli.default_type: idea`
+- **THEN** `vault.DefaultType()` SHALL return `"idea"`
+
+#### Scenario: Default type is not configured
+
+- **WHEN** config does not have `cli.default_type`
+- **THEN** `vault.DefaultType()` SHALL return `""`
+
+### Requirement: Init creates config.yaml when starter types are selected
+
+When `tmd init` writes starter types and the user selects the `idea` or `note` type, it SHALL also create `.typemd/config.yaml` with `cli.default_type` set to `idea` (if selected) or `note` (if selected without idea). If neither is selected, no config file SHALL be created.
+
+#### Scenario: Init with idea starter selected
+
+- **WHEN** `tmd init` is run and user selects the `idea` starter type
+- **THEN** `.typemd/config.yaml` SHALL be created with `cli:\n  default_type: idea`
+
+#### Scenario: Init with note starter selected but not idea
+
+- **WHEN** `tmd init` is run and user selects the `note` starter type but not `idea`
+- **THEN** `.typemd/config.yaml` SHALL be created with `cli:\n  default_type: note`
+
+#### Scenario: Init with no quick-suitable starter selected
+
+- **WHEN** `tmd init` is run and user selects only the `book` starter type
+- **THEN** no `.typemd/config.yaml` SHALL be created

--- a/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/tasks.md
+++ b/openspec/changes/archive/2026-03-16-issue-236-enhance-object-create/tasks.md
@@ -1,0 +1,40 @@
+## 1. Core: Vault Config
+
+- [x] 1.1 Write BDD scenarios for vault config loading (file exists, missing, empty, invalid YAML)
+- [x] 1.2 Implement BDD step definitions for vault config scenarios
+- [x] 1.3 Add `VaultConfig` and `CLIConfig` structs, config loading in `Vault.Open()`
+- [x] 1.4 Add `DefaultType()` accessor method on Vault
+- [x] 1.5 Add unit tests for config edge cases (unknown keys ignored, partial config)
+
+## 2. Core: Slug Conversion
+
+- [x] 2.1 Write BDD scenarios for slug conversion (spaces, mixed case, special chars, idempotent)
+- [x] 2.2 Implement BDD step definitions for slug conversion scenarios
+- [x] 2.3 Add `Slugify()` function in core package
+- [x] 2.4 Add unit tests for slug edge cases (empty string, non-ASCII, numbers, consecutive hyphens)
+
+## 3. Core: ObjectService.Create Slug Integration
+
+- [x] 3.1 Write BDD scenarios for Create with natural-language names (slug for filename, original for name property)
+- [x] 3.2 Implement BDD step definitions for Create slug scenarios
+- [x] 3.3 Modify `ObjectService.Create()` to apply `Slugify()` to filename and preserve original input as name property
+- [x] 3.4 Add unit tests for backward compatibility (pre-slugified input unchanged)
+
+## 4. CLI: Type Argument Optional + --type Flag
+
+- [x] 4.1 Add `--type` flag to `createCmd` (no `-t` short form)
+- [x] 4.2 Change args validation from `RangeArgs(1, 2)` to `RangeArgs(0, 2)`
+- [x] 4.3 Implement type resolution logic (0/1/2 args + flag + config fallback)
+- [x] 4.4 Add unit tests for arg resolution (0 args, 1 arg as type, 1 arg as name, 2 args, flag override)
+
+## 5. CLI: Init Config Generation
+
+- [x] 5.1 Modify `tmd init` to create `config.yaml` when idea or note starter is selected
+- [x] 5.2 Add unit tests for init config generation (idea selected, note only, neither selected)
+
+## 6. Integration Verification
+
+- [x] 6.1 Run full test suite (`go test ./...`) and verify no regressions
+- [x] 6.2 Manual test: `tmd object create "Some Thought"` with config default type
+- [x] 6.3 Manual test: `tmd object create --type note "Meeting Notes"`
+- [x] 6.4 Manual test: `tmd object create book "Clean Code"` (backward compatible)

--- a/openspec/specs/object-templates/spec.md
+++ b/openspec/specs/object-templates/spec.md
@@ -176,3 +176,67 @@ When a type has multiple templates and no `-t` flag is specified, `tmd object cr
 - **WHEN** `tmd object create book my-book -t review` is executed
 - **AND** `templates/book/` contains `review.md` and `summary.md`
 - **THEN** the object SHALL be created using `review` without prompting
+
+### Requirement: CLI create command supports type flag
+
+The `tmd object create` command SHALL accept an optional `--type` flag to specify the object type. When `--type` is provided, all positional arguments are treated as the name. The `--type` flag SHALL NOT have a `-t` short form (reserved by `--template`).
+
+#### Scenario: Create with --type flag and name
+
+- **WHEN** `tmd object create --type note "Meeting Notes"` is executed
+- **THEN** the object SHALL be created with type `note` and name `"Meeting Notes"`
+
+#### Scenario: Create with --type flag and no name
+
+- **WHEN** `tmd object create --type idea` is executed
+- **AND** the `idea` type has a name template
+- **THEN** the object SHALL be created with the auto-generated name
+
+#### Scenario: Create with --type flag overriding config default
+
+- **WHEN** config has `cli.default_type: idea`
+- **AND** `tmd object create --type note "Meeting Notes"` is executed
+- **THEN** the object SHALL be created with type `note` (flag overrides config)
+
+### Requirement: CLI create command type argument is optional
+
+The `tmd object create` command SHALL accept 0 to 2 positional arguments. When the type is not provided as a positional argument, it SHALL be resolved from the `--type` flag or `cli.default_type` config.
+
+#### Scenario: Zero args with config default type and name template
+
+- **WHEN** `tmd object create` is executed with no arguments
+- **AND** config has `cli.default_type: idea`
+- **AND** the `idea` type has a name template
+- **THEN** the object SHALL be created with type `idea` and auto-generated name
+
+#### Scenario: Zero args without config or flag
+
+- **WHEN** `tmd object create` is executed with no arguments
+- **AND** no `--type` flag is provided
+- **AND** no `cli.default_type` is configured
+- **THEN** the command SHALL return an error indicating type is required
+
+#### Scenario: One arg resolved as type (backward compatible)
+
+- **WHEN** `tmd object create book` is executed
+- **AND** `book` is a valid type in the vault
+- **THEN** the object SHALL be created with type `book` (backward compatible behavior)
+
+#### Scenario: One arg resolved as name with config default
+
+- **WHEN** `tmd object create "Some Thought"` is executed
+- **AND** `"Some Thought"` is NOT a valid type in the vault
+- **AND** config has `cli.default_type: idea`
+- **THEN** the object SHALL be created with type `idea` and name `"Some Thought"`
+
+#### Scenario: One arg not a valid type and no default
+
+- **WHEN** `tmd object create "Some Thought"` is executed
+- **AND** `"Some Thought"` is NOT a valid type in the vault
+- **AND** no `cli.default_type` is configured and no `--type` flag provided
+- **THEN** the command SHALL return an error indicating unknown type
+
+#### Scenario: Two args (backward compatible)
+
+- **WHEN** `tmd object create book "Clean Code"` is executed
+- **THEN** the object SHALL be created with type `book` and name `"Clean Code"` (unchanged behavior)

--- a/openspec/specs/slug-conversion/spec.md
+++ b/openspec/specs/slug-conversion/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Slugify converts natural-language names to valid slugs
+
+The `Slugify(name string)` function SHALL convert a natural-language string to a valid slug suitable for filenames and ObjectIDs. The conversion SHALL:
+1. Convert to lowercase
+2. Replace spaces and underscores with hyphens
+3. Remove characters that are not alphanumeric or hyphens
+4. Collapse consecutive hyphens into a single hyphen
+5. Trim leading and trailing hyphens
+
+#### Scenario: Simple name with spaces
+
+- **WHEN** `Slugify("Some Thought")` is called
+- **THEN** it SHALL return `"some-thought"`
+
+#### Scenario: Name with mixed case
+
+- **WHEN** `Slugify("Clean Code")` is called
+- **THEN** it SHALL return `"clean-code"`
+
+#### Scenario: Name with underscores
+
+- **WHEN** `Slugify("my_great_idea")` is called
+- **THEN** it SHALL return `"my-great-idea"`
+
+#### Scenario: Name with special characters
+
+- **WHEN** `Slugify("What's the plan?")` is called
+- **THEN** it SHALL return `"whats-the-plan"`
+
+#### Scenario: Name with consecutive spaces
+
+- **WHEN** `Slugify("too   many   spaces")` is called
+- **THEN** it SHALL return `"too-many-spaces"`
+
+#### Scenario: Name with leading/trailing whitespace
+
+- **WHEN** `Slugify("  padded name  ")` is called
+- **THEN** it SHALL return `"padded-name"`
+
+#### Scenario: Already-slugified input is idempotent
+
+- **WHEN** `Slugify("clean-code")` is called
+- **THEN** it SHALL return `"clean-code"`
+
+#### Scenario: Empty string
+
+- **WHEN** `Slugify("")` is called
+- **THEN** it SHALL return `""`
+
+#### Scenario: Name with numbers
+
+- **WHEN** `Slugify("Chapter 3 Notes")` is called
+- **THEN** it SHALL return `"chapter-3-notes"`
+
+#### Scenario: Name with non-ASCII characters
+
+- **WHEN** `Slugify("café latte")` is called
+- **THEN** it SHALL return `"caf-latte"`
+
+### Requirement: ObjectService.Create applies slug conversion to filename
+
+`ObjectService.Create()` SHALL apply `Slugify()` to the filename parameter when generating the ObjectID. The original (pre-slugified) input SHALL be used as the `name` property value.
+
+#### Scenario: Natural-language name is slugified for filename
+
+- **WHEN** `ObjectService.Create("idea", "Some Great Thought", "")` is called
+- **THEN** the ObjectID filename SHALL contain `some-great-thought-<ULID>`
+- **AND** the `name` property SHALL be `"Some Great Thought"`
+
+#### Scenario: Pre-slugified name passes through unchanged
+
+- **WHEN** `ObjectService.Create("idea", "already-slugified", "")` is called
+- **THEN** the ObjectID filename SHALL contain `already-slugified-<ULID>`
+- **AND** the `name` property SHALL be `"already-slugified"`

--- a/openspec/specs/vault-config/spec.md
+++ b/openspec/specs/vault-config/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: Vault loads config from `.typemd/config.yaml`
+
+The Vault SHALL load configuration from `.typemd/config.yaml` during `Open()`. The config file is optional — if the file does not exist or is empty, the Vault SHALL use zero-value defaults with no error.
+
+#### Scenario: Config file exists with valid content
+
+- **WHEN** `.typemd/config.yaml` contains `cli:\n  default_type: idea`
+- **THEN** the Vault SHALL load the config with `CLI.DefaultType` set to `"idea"`
+
+#### Scenario: Config file does not exist
+
+- **WHEN** `.typemd/config.yaml` does not exist
+- **THEN** the Vault SHALL use an empty config with all fields at zero values
+- **AND** no error SHALL be returned
+
+#### Scenario: Config file is empty
+
+- **WHEN** `.typemd/config.yaml` exists but is empty
+- **THEN** the Vault SHALL use an empty config with all fields at zero values
+- **AND** no error SHALL be returned
+
+#### Scenario: Config file has invalid YAML
+
+- **WHEN** `.typemd/config.yaml` contains invalid YAML syntax
+- **THEN** the Vault SHALL return an error during `Open()`
+
+### Requirement: Config struct uses interface-layer namespacing
+
+The `VaultConfig` struct SHALL organize settings under interface-layer keys: `cli`, `tui` (future). Each interface layer SHALL have its own sub-struct.
+
+#### Scenario: CLI config with default_type
+
+- **WHEN** config contains `cli:\n  default_type: note`
+- **THEN** `config.CLI.DefaultType` SHALL be `"note"`
+
+#### Scenario: Unknown top-level keys are ignored
+
+- **WHEN** config contains `unknown_key: value` alongside valid keys
+- **THEN** the Vault SHALL load successfully, ignoring the unknown key
+
+### Requirement: Vault exposes DefaultType accessor
+
+The Vault SHALL provide a `DefaultType()` method that returns the configured `cli.default_type` value. If no default type is configured, it SHALL return an empty string.
+
+#### Scenario: Default type is configured
+
+- **WHEN** config has `cli.default_type: idea`
+- **THEN** `vault.DefaultType()` SHALL return `"idea"`
+
+#### Scenario: Default type is not configured
+
+- **WHEN** config does not have `cli.default_type`
+- **THEN** `vault.DefaultType()` SHALL return `""`
+
+### Requirement: Init creates config.yaml when starter types are selected
+
+When `tmd init` writes starter types and the user selects the `idea` or `note` type, it SHALL also create `.typemd/config.yaml` with `cli.default_type` set to `idea` (if selected) or `note` (if selected without idea). If neither is selected, no config file SHALL be created.
+
+#### Scenario: Init with idea starter selected
+
+- **WHEN** `tmd init` is run and user selects the `idea` starter type
+- **THEN** `.typemd/config.yaml` SHALL be created with `cli:\n  default_type: idea`
+
+#### Scenario: Init with note starter selected but not idea
+
+- **WHEN** `tmd init` is run and user selects the `note` starter type but not `idea`
+- **THEN** `.typemd/config.yaml` SHALL be created with `cli:\n  default_type: note`
+
+#### Scenario: Init with no quick-suitable starter selected
+
+- **WHEN** `tmd init` is run and user selects only the `book` starter type
+- **THEN** no `.typemd/config.yaml` SHALL be created

--- a/websites/docs/src/content/docs/advanced/file-structure.md
+++ b/websites/docs/src/content/docs/advanced/file-structure.md
@@ -17,6 +17,7 @@ vault/
 │   ├── types/              # user-defined type schemas (YAML)
 │   │   ├── book.yaml       # example: you create this
 │   │   └── person.yaml     # example: you create this
+│   ├── config.yaml         # vault configuration (optional)
 │   ├── properties.yaml     # shared property definitions (optional)
 │   ├── index.db            # SQLite index (auto-updated)
 │   └── tui-state.yaml      # TUI session state (auto-saved)
@@ -30,7 +31,7 @@ vault/
         └── alan-donovan-01jqr3k5mpbvn8e0f2g7h9txyz.md
 ```
 
-- `.typemd/` — configuration and internal state (type schemas, shared properties, index, TUI state)
+- `.typemd/` — configuration and internal state (vault config, type schemas, shared properties, index, TUI state)
 - `templates/` — optional object templates organized by type
 - `objects/` — all Object files organized by type
 
@@ -60,7 +61,7 @@ All Objects have five system properties managed by TypeMD. These always appear f
 
 | Property | Description | Mutable |
 |----------|-------------|---------|
-| `name` | Display name, auto-populated from the slug on creation | User-authored |
+| `name` | Display name, preserves the original input on creation (auto-derived from slug for pre-slugified names) | User-authored |
 | `description` | Optional single-line summary for list displays and search results | User-authored |
 | `created_at` | Creation timestamp in RFC 3339 format (set once, never modified) | Auto-managed |
 | `updated_at` | Last-modified timestamp in RFC 3339 format (updated on every save) | Auto-managed |
@@ -113,13 +114,13 @@ Each type can have one or more templates at `templates/<type>/<name>.md`. Templa
 
 ```bash
 # Single template — auto-applied
-tmd object create book clean-code
+tmd object create book "Clean Code"
 
 # Explicit template selection
-tmd object create book clean-code -t review
+tmd object create book "Clean Code" -t review
 
 # Multiple templates, no flag — interactive selection
-tmd object create book clean-code
+tmd object create book "Clean Code"
 ```
 
 Template frontmatter properties override schema defaults. The template body becomes the initial Object body. Auto-managed system properties (`created_at`, `updated_at`) in templates are ignored.

--- a/websites/docs/src/content/docs/cli/create.md
+++ b/websites/docs/src/content/docs/cli/create.md
@@ -8,12 +8,17 @@ sidebar:
 Creates a new object file (Markdown + YAML frontmatter) based on the type schema.
 
 ```bash
-tmd object create <type> [name]
-tmd object create book clean-code
-tmd object create book clean-code -t review
-tmd object create person robert-martin
-tmd object create journal
+tmd object create [type] [name]
+tmd object create book "Clean Code"
+tmd object create book "Clean Code" -t review
+tmd object create --type idea "Some Thought"
+tmd object create "Some Thought"              # uses default type from config
+tmd object create book
 ```
+
+The `type` argument can be omitted if `--type` flag is set or `cli.default_type` is configured in `.typemd/config.yaml`. When a single argument matches a known type name, it is treated as the type. To use a name that collides with a type name, use the `--type` flag explicitly.
+
+Names are automatically converted to slugs for the filename (e.g., "Clean Code" becomes `clean-code` in the filename), while the original input is preserved as the `name` property in frontmatter.
 
 If the type has a name template, the `name` argument is optional — the name will be auto-generated from the template. When no name is provided and no name template is defined, an error is returned.
 
@@ -25,7 +30,26 @@ Each object is assigned a unique ULID suffix, so multiple objects of the same ty
 
 | Flag | Description |
 |------|-------------|
+| `--type` | Object type (overrides config default, no short form) |
 | `-t`, `--template` | Template name to use (from `templates/<type>/`) |
+
+## Default type
+
+If `cli.default_type` is configured in `.typemd/config.yaml`, you can omit the type argument:
+
+```yaml
+# .typemd/config.yaml
+cli:
+  default_type: idea
+```
+
+```bash
+# These are equivalent when default_type is "idea":
+tmd object create idea "Some Thought"
+tmd object create "Some Thought"
+```
+
+The `--type` flag always takes precedence over the config default.
 
 ## Templates
 

--- a/websites/docs/src/content/docs/cli/init.md
+++ b/websites/docs/src/content/docs/cli/init.md
@@ -33,4 +33,14 @@ tmd init
 tmd init --no-starters
 ```
 
+### Vault configuration
+
+When starter types are selected, `tmd init` also creates `.typemd/config.yaml` with a default type for quick object creation:
+
+- If **idea** is selected → `cli.default_type: idea`
+- If **note** is selected (without idea) → `cli.default_type: note`
+- If only **book** is selected → no config file is created
+
+This enables `tmd object create "Some Thought"` without specifying a type. See [tmd object create](/cli/create) for details.
+
 Running `tmd init` on an already-initialized vault will return an error.

--- a/websites/docs/src/content/docs/developers/data-model.md
+++ b/websites/docs/src/content/docs/developers/data-model.md
@@ -69,6 +69,24 @@ tmd search "golang" --json
 
 In the TUI, press `/` to enter search mode. Results are filtered in real-time. Press `Esc` to clear results and return to the full list.
 
+## Vault configuration
+
+An optional configuration file at `.typemd/config.yaml` provides vault-level settings. The file uses interface-layer namespacing:
+
+```yaml
+# .typemd/config.yaml
+cli:
+  default_type: idea
+```
+
+Currently supported settings:
+
+| Key | Description |
+|-----|-------------|
+| `cli.default_type` | Default object type for `tmd object create` when type argument is omitted |
+
+The config file is loaded during vault open. If the file is missing or empty, all settings use their zero values (no error). Invalid YAML produces an error.
+
 ## Unique constraint enforcement
 
 Type schemas can opt into name uniqueness by setting `unique: true`. When enabled, TypeMD prevents creating multiple Objects of the same type with identical `name` values.

--- a/websites/docs/src/content/docs/getting-started/quick-start.md
+++ b/websites/docs/src/content/docs/getting-started/quick-start.md
@@ -48,9 +48,11 @@ properties:
 Use the CLI to create an object:
 
 ```bash
-tmd object create book golang-in-action
-# Created: book/golang-in-action
+tmd object create book "Go in Action"
+# Created: book/go-in-action-01jqr3k5mpbvn8e0f2g7h9txyz
 ```
+
+Names with spaces are automatically converted to slugs (e.g., "Go in Action" → `go-in-action`). The original name is preserved in the `name` frontmatter property.
 
 The CLI automatically appends a ULID to the slug for uniqueness. Alternatively, you can create a file manually at `objects/book/golang-in-action.md` — manual files do not require a ULID and are backward compatible.
 

--- a/websites/docs/src/content/docs/zh-tw/advanced/file-structure.md
+++ b/websites/docs/src/content/docs/zh-tw/advanced/file-structure.md
@@ -17,6 +17,7 @@ vault/
 │   ├── types/              # 使用者定義的 type schema（YAML）
 │   │   ├── book.yaml       # 範例：由你建立
 │   │   └── person.yaml     # 範例：由你建立
+│   ├── config.yaml         # vault 設定（選填）
 │   ├── properties.yaml     # 共用屬性定義（選填）
 │   ├── index.db            # SQLite 索引（自動更新）
 │   └── tui-state.yaml      # TUI 會話狀態（自動儲存）
@@ -30,7 +31,7 @@ vault/
         └── alan-donovan-01jqr3k5mpbvn8e0f2g7h9txyz.md
 ```
 
-- `.typemd/` — 設定與內部狀態（type schema、共用屬性、索引、TUI 狀態）
+- `.typemd/` — 設定與內部狀態（vault 設定、type schema、共用屬性、索引、TUI 狀態）
 - `templates/` — 選填的 object template，依 type 分類
 - `objects/` — 所有 Object 檔案，依 type 分類
 

--- a/websites/docs/src/content/docs/zh-tw/cli/create.md
+++ b/websites/docs/src/content/docs/zh-tw/cli/create.md
@@ -8,35 +8,55 @@ sidebar:
 根據 Type schema 建立新的 Object 檔案（Markdown + YAML frontmatter）。
 
 ```bash
-tmd object create book clean-code
-tmd object create person robert-martin
+tmd object create [type] [name]
+tmd object create book "Clean Code"
+tmd object create book "Clean Code" -t review
+tmd object create --type idea "Some Thought"
+tmd object create "Some Thought"              # 使用 config 中的預設 type
+tmd object create book
 ```
+
+`type` 參數可以省略，前提是設定了 `--type` flag 或在 `.typemd/config.yaml` 中設定了 `cli.default_type`。當只提供一個參數且該參數是已知的 type 名稱時，會被視為 type。若名稱與 type 名稱相同，請使用 `--type` flag 明確指定。
+
+名稱會自動轉換為 slug 作為檔名（例如 "Clean Code" 會變成 `clean-code`），而原始輸入會保留在 frontmatter 的 `name` 屬性中。
+
+如果 type schema 定義了 name template，可以省略 `name` 參數——名稱會從 template 自動產生。若未提供名稱也沒有 name template，會回傳錯誤。
 
 指令會在 `objects/<type>/` 下產生 `.md` 檔案，所有 schema 定義的屬性設為預設值（若無預設值則為 `null`）。Object 同時會被加入 SQLite 索引。
 
 每個 Object 會被分配唯一的 ULID 後綴，因此同一 Type 下可以有相同名稱的物件（例如兩個 `book/clean-code-<ulid>` 但 ULID 不同）。如果 Type 不存在，會回傳錯誤。
 
-## 單一參數用法
+## Flags
 
-如果 type schema 定義了 name template，可以省略第二個參數（slug）。TypeMD 會從 name template 自動產生名稱：
+| Flag | 說明 |
+|------|------|
+| `--type` | Object type（覆蓋 config 預設值，無短旗標） |
+| `-t`, `--template` | 要使用的 template 名稱（來自 `templates/<type>/`） |
 
-```bash
-# 使用 name template 自動產生名稱
-tmd object create meeting
+## 預設 Type
+
+如果在 `.typemd/config.yaml` 中設定了 `cli.default_type`，可以省略 type 參數：
+
+```yaml
+# .typemd/config.yaml
+cli:
+  default_type: idea
 ```
 
-若 type 沒有定義 name template，則必須提供 slug 參數。
+```bash
+# 當 default_type 是 "idea" 時，以下兩種寫法等效：
+tmd object create idea "Some Thought"
+tmd object create "Some Thought"
+```
+
+`--type` flag 永遠優先於 config 預設值。
 
 ## Template
 
-使用 `-t` / `--template` flag 指定要套用的 object template：
+如果該 type 在 `templates/<type>/` 下有定義 template，會自動解析：
 
-```bash
-# 指定 template
-tmd object create book clean-code -t review
-tmd object create book clean-code --template review
-```
-
-Template 檔案位於 `templates/<type>/<name>.md`。如果該 type 只有一個 template，建立 object 時會自動套用，不需要 `-t` flag。如果有多個 template 且未指定 `-t`，會出現互動式選擇提示。
+- **沒有 template** — 不套用任何 template
+- **單一 template** — 自動套用，不需提示
+- **多個 template** — 互動式選擇提示（或使用 `-t` 跳過提示）
 
 Template 的 frontmatter 屬性會覆蓋 schema 預設值，template 的內文會成為 object 的初始內文。自動管理的系統屬性（`created_at`、`updated_at`）在 template 中會被忽略。

--- a/websites/docs/src/content/docs/zh-tw/cli/init.md
+++ b/websites/docs/src/content/docs/zh-tw/cli/init.md
@@ -33,4 +33,14 @@ tmd init
 tmd init --no-starters
 ```
 
+### Vault 設定
+
+選取 starter types 時，`tmd init` 也會建立 `.typemd/config.yaml`，設定快速建立 object 的預設 type：
+
+- 選取 **idea** → `cli.default_type: idea`
+- 選取 **note**（沒有 idea）→ `cli.default_type: note`
+- 只選取 **book** → 不建立 config 檔
+
+這讓你可以直接執行 `tmd object create "Some Thought"` 而不需指定 type。詳見 [tmd object create](/zh-tw/cli/create)。
+
 在已初始化的 vault 上執行 `tmd init` 會回傳錯誤。

--- a/websites/docs/src/content/docs/zh-tw/developers/data-model.md
+++ b/websites/docs/src/content/docs/zh-tw/developers/data-model.md
@@ -83,3 +83,21 @@ properties:
 ```
 
 唯一性在建立時透過檢查索引中是否已存在相同 type 和 name 的 Object 來強制執行。也可透過 `tmd type validate` 驗證。內建的 `tag` type 預設啟用 `unique: true`。
+
+## Vault 設定
+
+`.typemd/config.yaml` 是選填的 vault 層級設定檔，使用介面層命名空間：
+
+```yaml
+# .typemd/config.yaml
+cli:
+  default_type: idea
+```
+
+目前支援的設定：
+
+| Key | 說明 |
+|-----|------|
+| `cli.default_type` | `tmd object create` 省略 type 參數時使用的預設 object type |
+
+Config 檔在 vault 開啟時載入。若檔案不存在或為空，所有設定使用零值（不會出錯）。無效的 YAML 會產生錯誤。


### PR DESCRIPTION
## Summary

- Add vault config system (`.typemd/config.yaml`) with `cli.default_type` setting, enabling `tmd object create` without specifying a type
- Add `--type` flag to `tmd object create` for explicit type override
- Auto-convert natural-language names to slugs for filenames while preserving original input as the `name` property
- Generate `config.yaml` during `tmd init` when idea or note starter type is selected
- Originally scoped as a separate `tmd quick` command (#236), but exploration revealed it duplicates `tmd object create` — enhanced existing command instead

## Issue

Closes #236

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [x] Manual: `tmd object create "Some Thought"` with config default type
- [x] Manual: `tmd object create --type note "Meeting Notes"`
- [x] Manual: `tmd object create book "Clean Code"` (backward compatible)