### PR TITLE
feat(core): add version field to type schemas (#45)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ graph LR
 | `projector.go` | Projector (file→index sync) |
 | `domain_event.go` | Domain event types + EventDispatcher |
 | `vault.go` | Vault facade + lifecycle (Open/Close/Init) |
-| `type_schema.go` | TypeSchema entity + validation + YAML serialization + Vault type CRUD (SaveType/DeleteType/CountObjectsByType) |
+| `type_schema.go` | TypeSchema entity + validation + YAML serialization + version handling (DefaultSchemaVersion, CompareVersions) + Vault type CRUD (SaveType/DeleteType/CountObjectsByType) |
 | `doctor.go` | Doctor health check: RunDoctor orchestrator, DoctorReport, issue categories |
 | `doctor_orphan.go` | OrphanDir scanning for objects/ and templates/ without type schemas |
 | `starters.go` | Embedded starter type templates (idea/note/book) + StarterTypes() + Vault.WriteStarterTypes() |
@@ -150,7 +150,7 @@ The right panel automatically follows the sidebar cursor: moving to an object sh
 
 - Objects identified by `type/<slug>-<ulid>` (e.g. `book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz`)
 - All objects have system properties managed by typemd: `name` (preserves original input on creation; auto-populated from slug for pre-slugified names, or from name template if defined), `description` (optional, user-authored), `created_at` (set on creation, immutable), `updated_at` (updated on save, immutable), `tags` (relation to built-in `tag` type, multiple). These appear first in frontmatter in that order. System properties are either **user-authored** (`name`, `description`, `tags` — can be overridden by templates) or **auto-managed** (`created_at`, `updated_at` — cannot be overridden).
-- Type schemas: `.typemd/types/*.yaml` (cannot define properties named `description`, `created_at`, `updated_at`, or `tags` — they're reserved system properties; `name` can appear in `properties` with only a `template` field for auto-generated names). Type schemas support optional `plural` (for display in collection contexts), `unique` (to enforce name uniqueness), and `version` (non-negative integer for schema migration tracking, default 0) fields.
+- Type schemas: `.typemd/types/*.yaml` (cannot define properties named `description`, `created_at`, `updated_at`, or `tags` — they're reserved system properties; `name` can appear in `properties` with only a `template` field for auto-generated names). Type schemas support optional `plural` (for display in collection contexts), `unique` (to enforce name uniqueness), and `version` (semver-style `"major.minor"` string for schema migration tracking, default `"0.0"`) fields.
 - Shared properties: `.typemd/properties.yaml` (optional, defines reusable property definitions referenced via `use` in type schemas)
 - Relations defined as properties in type schemas
 - Wiki-links: `[[type/name-ulid]]` syntax in markdown body, with backlink tracking

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ The optional `unique` field (boolean, defaults to `false`) enforces that no two 
 
 Types and properties both support an optional `emoji` field for visual identification in CLI and TUI output. Properties also support an optional `default` field to specify a default value.
 
-The optional `version` field (non-negative integer, defaults to `0`) tracks schema evolution. Increment it manually when making breaking changes to a type schema, providing a foundation for future migration tooling.
+The optional `version` field (semver-style `"major.minor"` string, defaults to `"0.0"`) tracks schema evolution. Increment the major number for breaking changes, and the minor number for backward-compatible changes, providing a foundation for future migration tooling.
 
 ## Relations
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -226,7 +226,7 @@ properties:
 
 Type 和屬性都支援可選的 `emoji` 欄位，用於在 CLI 和 TUI 輸出中視覺辨識。屬性還支援可選的 `default` 欄位來指定預設值。
 
-可選的 `version` 欄位（非負整數，預設為 `0`）用於追蹤 schema 演進。當 type schema 有重大變更時，可手動遞增版本號，為未來的遷移工具奠定基礎。
+可選的 `version` 欄位（semver 風格的 `"major.minor"` 字串，預設為 `"0.0"`）用於追蹤 schema 演進。Major 代表破壞性變更，minor 代表向下相容的變更，為未來的遷移工具奠定基礎。
 
 ## Relation
 

--- a/core/bdd_steps_type_crud_test.go
+++ b/core/bdd_steps_type_crud_test.go
@@ -121,18 +121,22 @@ func (tc *typeCrudContext) iDeserializeTheYAMLOutputBackToATypeSchema() error {
 		Plural     string     `yaml:"plural,omitempty"`
 		Emoji      string     `yaml:"emoji,omitempty"`
 		Unique     bool       `yaml:"unique,omitempty"`
-		Version    int        `yaml:"version,omitempty"`
+		Version    string     `yaml:"version,omitempty"`
 		Properties []Property `yaml:"properties"`
 	}
 	if err := yaml.Unmarshal(tc.yamlOutput, &raw); err != nil {
 		return err
+	}
+	version := raw.Version
+	if version == "" {
+		version = DefaultSchemaVersion
 	}
 	schema := &TypeSchema{
 		Name:       raw.Name,
 		Plural:     raw.Plural,
 		Emoji:      raw.Emoji,
 		Unique:     raw.Unique,
-		Version:    raw.Version,
+		Version:    version,
 		Properties: raw.Properties,
 	}
 	// Extract NameTemplate like GetSchema does
@@ -255,7 +259,7 @@ func (tc *typeCrudContext) theCountShouldBe(expected int) error {
 
 // ── Version steps ───────────────────────────────────────────────────────────
 
-func (tc *typeCrudContext) theSchemaHasVersion(version int) {
+func (tc *typeCrudContext) theSchemaHasVersion(version string) {
 	tc.schema.Version = version
 }
 
@@ -263,9 +267,9 @@ func (tc *typeCrudContext) iValidateTheTypeSchema() {
 	tc.validationErrs = ValidateSchema(tc.schema)
 }
 
-func (tc *typeCrudContext) theRoundTripSchemaVersionShouldBe(expected int) error {
+func (tc *typeCrudContext) theRoundTripSchemaVersionShouldBe(expected string) error {
 	if tc.roundTripSchema.Version != expected {
-		return fmt.Errorf("expected version %d, got %d", expected, tc.roundTripSchema.Version)
+		return fmt.Errorf("expected version %q, got %q", expected, tc.roundTripSchema.Version)
 	}
 	return nil
 }
@@ -287,6 +291,14 @@ func (tc *typeCrudContext) aSchemaValidationErrorShouldMention(substr string) er
 		}
 	}
 	return fmt.Errorf("expected error mentioning %q, got %v", substr, tc.validationErrs)
+}
+
+func (tc *typeCrudContext) comparingVersionWithShouldReturn(a, b string, expected int) error {
+	result := CompareVersions(a, b)
+	if result != expected {
+		return fmt.Errorf("CompareVersions(%q, %q) = %d, want %d", a, b, result, expected)
+	}
+	return nil
 }
 
 // ── Init ────────────────────────────────────────────────────────────────────
@@ -328,9 +340,10 @@ func initTypeCrudSteps(ctx *godog.ScenarioContext, dc *domainContext) {
 	ctx.Step(`^the count should be (\d+)$`, tc.theCountShouldBe)
 
 	// Version steps
-	ctx.Step(`^the schema has version (-?\d+)$`, tc.theSchemaHasVersion)
+	ctx.Step(`^the schema has version "([^"]*)"$`, tc.theSchemaHasVersion)
 	ctx.Step(`^I validate the type schema$`, tc.iValidateTheTypeSchema)
-	ctx.Step(`^the round-trip schema version should be (-?\d+)$`, tc.theRoundTripSchemaVersionShouldBe)
+	ctx.Step(`^the round-trip schema version should be "([^"]*)"$`, tc.theRoundTripSchemaVersionShouldBe)
 	ctx.Step(`^no schema validation errors should occur$`, tc.noSchemaValidationErrorsShouldOccur)
 	ctx.Step(`^a schema validation error should mention "([^"]*)"$`, tc.aSchemaValidationErrorShouldMention)
+	ctx.Step(`^comparing version "([^"]*)" with "([^"]*)" should return (-?\d+)$`, tc.comparingVersionWithShouldReturn)
 }

--- a/core/features/type_schema_version.feature
+++ b/core/features/type_schema_version.feature
@@ -1,13 +1,13 @@
 Feature: Type Schema Version
-  Type schemas support a version field for tracking schema evolution.
+  Type schemas support a semver-style "major.minor" version field for tracking schema evolution.
 
   # ── Serialization ──────────────────────────────────────────
 
   Scenario: Schema with version serializes to YAML
     Given a type schema "book" with no extra fields
-    And the schema has version 1
+    And the schema has version "1.0"
     When I serialize the type schema
-    Then the YAML output should contain "version: 1"
+    Then the YAML output should contain "version: \"1.0\""
 
   Scenario: Schema without version omits version from YAML
     Given a type schema "note" with no extra fields
@@ -16,22 +16,22 @@ Feature: Type Schema Version
 
   Scenario: Schema version round-trips through marshal/unmarshal
     Given a type schema "book" with no extra fields
-    And the schema has version 3
+    And the schema has version "2.3"
     When I serialize the type schema
     And I deserialize the YAML output back to a TypeSchema
-    Then the round-trip schema version should be 3
+    Then the round-trip schema version should be "2.3"
 
-  Scenario: Schema without version defaults to 0 on load
+  Scenario: Schema without version defaults to 0.0 on load
     Given a type schema "note" with no extra fields
     When I serialize the type schema
     And I deserialize the YAML output back to a TypeSchema
-    Then the round-trip schema version should be 0
+    Then the round-trip schema version should be "0.0"
 
   # ── Validation ─────────────────────────────────────────────
 
-  Scenario: Schema with positive version passes validation
+  Scenario: Schema with valid version passes validation
     Given a type schema "book" with no extra fields
-    And the schema has version 1
+    And the schema has version "2.3"
     When I validate the type schema
     Then no schema validation errors should occur
 
@@ -40,8 +40,46 @@ Feature: Type Schema Version
     When I validate the type schema
     Then no schema validation errors should occur
 
-  Scenario: Schema with negative version fails validation
+  Scenario: Single number version fails validation
     Given a type schema "book" with no extra fields
-    And the schema has version -1
+    And the schema has version "1"
     When I validate the type schema
-    Then a schema validation error should mention "non-negative"
+    Then a schema validation error should mention "major.minor"
+
+  Scenario: Three segments version fails validation
+    Given a type schema "book" with no extra fields
+    And the schema has version "1.0.0"
+    When I validate the type schema
+    Then a schema validation error should mention "major.minor"
+
+  Scenario: Leading zeros version fails validation
+    Given a type schema "book" with no extra fields
+    And the schema has version "01.0"
+    When I validate the type schema
+    Then a schema validation error should mention "major.minor"
+
+  Scenario: Negative number version fails validation
+    Given a type schema "book" with no extra fields
+    And the schema has version "-1.0"
+    When I validate the type schema
+    Then a schema validation error should mention "major.minor"
+
+  Scenario: Non-numeric version fails validation
+    Given a type schema "book" with no extra fields
+    And the schema has version "abc"
+    When I validate the type schema
+    Then a schema validation error should mention "major.minor"
+
+  # ── Comparison ─────────────────────────────────────────────
+
+  Scenario: Higher major version is greater
+    Then comparing version "2.0" with "1.3" should return 1
+
+  Scenario: Higher minor version is greater
+    Then comparing version "1.2" with "1.1" should return 1
+
+  Scenario: Equal versions
+    Then comparing version "1.1" with "1.1" should return 0
+
+  Scenario: Lower version is less
+    Then comparing version "0.1" with "1.0" should return -1

--- a/core/local_object_repository.go
+++ b/core/local_object_repository.go
@@ -279,6 +279,11 @@ func (r *LocalObjectRepository) GetSchema(name string) (*TypeSchema, error) {
 		}
 		schema.Properties = filtered
 
+		// Normalize empty version to default
+		if schema.Version == "" {
+			schema.Version = DefaultSchemaVersion
+		}
+
 		// Resolve use entries if any exist
 		if err := r.resolveSchemaUseEntries(&schema); err != nil {
 			return nil, fmt.Errorf("resolve type schema %s: %w", name, err)
@@ -288,6 +293,9 @@ func (r *LocalObjectRepository) GetSchema(name string) (*TypeSchema, error) {
 	}
 
 	if schema, ok := defaultTypes[name]; ok {
+		if schema.Version == "" {
+			schema.Version = DefaultSchemaVersion
+		}
 		return &schema, nil
 	}
 

--- a/core/type_schema.go
+++ b/core/type_schema.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -61,13 +63,16 @@ func OrderedPropKeys(props map[string]any, schema *TypeSchema) []string {
 	return append(prefix, keys...)
 }
 
+// DefaultSchemaVersion is the default version for type schemas without an explicit version.
+const DefaultSchemaVersion = "0.0"
+
 // TypeSchema defines the schema for a type.
 type TypeSchema struct {
 	Name         string     `yaml:"name"`
 	Plural       string     `yaml:"plural,omitempty"`
 	Emoji        string     `yaml:"emoji,omitempty"`
 	Unique       bool       `yaml:"unique,omitempty"`
-	Version      int        `yaml:"version,omitempty"`
+	Version      string     `yaml:"version,omitempty"`
 	Properties   []Property `yaml:"properties"`
 	NameTemplate string     `yaml:"-"` // extracted from name property entry during load
 }
@@ -247,8 +252,10 @@ func ValidateSchema(schema *TypeSchema, sharedProps ...[]Property) []error {
 	if schema.Name == "" {
 		errs = append(errs, fmt.Errorf("schema missing required field: name"))
 	}
-	if schema.Version < 0 {
-		errs = append(errs, fmt.Errorf("schema version must be non-negative, got %d", schema.Version))
+	if schema.Version != "" && schema.Version != DefaultSchemaVersion {
+		if err := validateVersion(schema.Version); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	// Build shared properties map if provided
@@ -579,7 +586,7 @@ type marshalSchema struct {
 	Plural     string     `yaml:"plural,omitempty"`
 	Emoji      string     `yaml:"emoji,omitempty"`
 	Unique     bool       `yaml:"unique,omitempty"`
-	Version    int        `yaml:"version,omitempty"`
+	Version    string     `yaml:"version,omitempty"`
 	Properties []Property `yaml:"properties"`
 }
 
@@ -587,12 +594,16 @@ type marshalSchema struct {
 // writing to .typemd/types/<name>.yaml. It handles the NameTemplate →
 // name property entry conversion that yaml:"-" would otherwise drop.
 func MarshalTypeSchema(schema *TypeSchema) ([]byte, error) {
+	version := schema.Version
+	if version == DefaultSchemaVersion {
+		version = "" // omit default version from YAML
+	}
 	ms := marshalSchema{
 		Name:    schema.Name,
 		Plural:  schema.Plural,
 		Emoji:   schema.Emoji,
 		Unique:  schema.Unique,
-		Version: schema.Version,
+		Version: version,
 	}
 
 	// Re-introduce name template as a name property entry if set
@@ -606,4 +617,52 @@ func MarshalTypeSchema(schema *TypeSchema) ([]byte, error) {
 	ms.Properties = append(ms.Properties, schema.Properties...)
 
 	return yaml.Marshal(&ms)
+}
+
+// parseVersion parses a "major.minor" version string into two integers.
+func parseVersion(v string) (int, int, error) {
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("version must be in \"major.minor\" format, got %q", v)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil || major < 0 {
+		return 0, 0, fmt.Errorf("version must be in \"major.minor\" format, got %q", v)
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil || minor < 0 {
+		return 0, 0, fmt.Errorf("version must be in \"major.minor\" format, got %q", v)
+	}
+	// Reject leading zeros (e.g. "01.0" or "0.01")
+	if parts[0] != strconv.Itoa(major) || parts[1] != strconv.Itoa(minor) {
+		return 0, 0, fmt.Errorf("version must be in \"major.minor\" format, got %q", v)
+	}
+	return major, minor, nil
+}
+
+// validateVersion checks that a version string is a valid "major.minor" format.
+func validateVersion(v string) error {
+	_, _, err := parseVersion(v)
+	return err
+}
+
+// CompareVersions compares two "major.minor" version strings.
+// Returns -1 if a < b, 0 if a == b, 1 if a > b.
+// Both versions must be valid; invalid versions are treated as "0.0".
+func CompareVersions(a, b string) int {
+	aMajor, aMinor, _ := parseVersion(a)
+	bMajor, bMinor, _ := parseVersion(b)
+	if aMajor != bMajor {
+		if aMajor < bMajor {
+			return -1
+		}
+		return 1
+	}
+	if aMinor != bMinor {
+		if aMinor < bMinor {
+			return -1
+		}
+		return 1
+	}
+	return 0
 }

--- a/core/type_schema_test.go
+++ b/core/type_schema_test.go
@@ -1104,7 +1104,7 @@ func TestValidateSchema_NameWithNoFieldsRejected(t *testing.T) {
 func TestTypeSchema_VersionField(t *testing.T) {
 	data := []byte(`
 name: book
-version: 2
+version: "2.3"
 properties:
   - name: title
     type: string
@@ -1113,12 +1113,12 @@ properties:
 	if err := yaml.Unmarshal(data, &schema); err != nil {
 		t.Fatalf("Unmarshal error = %v", err)
 	}
-	if schema.Version != 2 {
-		t.Errorf("Version = %d, want 2", schema.Version)
+	if schema.Version != "2.3" {
+		t.Errorf("Version = %q, want %q", schema.Version, "2.3")
 	}
 }
 
-func TestTypeSchema_VersionOmittedDefaultsToZero(t *testing.T) {
+func TestTypeSchema_VersionOmittedDefaultsToEmpty(t *testing.T) {
 	data := []byte(`
 name: book
 properties:
@@ -1129,13 +1129,13 @@ properties:
 	if err := yaml.Unmarshal(data, &schema); err != nil {
 		t.Fatalf("Unmarshal error = %v", err)
 	}
-	if schema.Version != 0 {
-		t.Errorf("Version = %d, want 0", schema.Version)
+	if schema.Version != "" {
+		t.Errorf("Version = %q, want empty string", schema.Version)
 	}
 }
 
-func TestTypeSchema_VersionZeroOmittedFromYAML(t *testing.T) {
-	schema := &TypeSchema{Name: "note", Version: 0}
+func TestTypeSchema_DefaultVersionOmittedFromYAML(t *testing.T) {
+	schema := &TypeSchema{Name: "note", Version: "0.0"}
 	data, err := MarshalTypeSchema(schema)
 	if err != nil {
 		t.Fatalf("MarshalTypeSchema error = %v", err)
@@ -1145,67 +1145,92 @@ func TestTypeSchema_VersionZeroOmittedFromYAML(t *testing.T) {
 	}
 }
 
-func TestTypeSchema_VersionOnePresent(t *testing.T) {
-	schema := &TypeSchema{Name: "book", Version: 1}
+func TestTypeSchema_EmptyVersionOmittedFromYAML(t *testing.T) {
+	schema := &TypeSchema{Name: "note"}
 	data, err := MarshalTypeSchema(schema)
 	if err != nil {
 		t.Fatalf("MarshalTypeSchema error = %v", err)
 	}
-	if !strings.Contains(string(data), "version: 1") {
-		t.Errorf("expected YAML to contain 'version: 1', got:\n%s", string(data))
+	if strings.Contains(string(data), "version:") {
+		t.Errorf("expected version to be omitted from YAML, got:\n%s", string(data))
 	}
 }
 
-func TestTypeSchema_LargeVersionNumber(t *testing.T) {
-	schema := &TypeSchema{Name: "book", Version: 999}
+func TestTypeSchema_VersionPresent(t *testing.T) {
+	schema := &TypeSchema{Name: "book", Version: "1.0"}
 	data, err := MarshalTypeSchema(schema)
 	if err != nil {
 		t.Fatalf("MarshalTypeSchema error = %v", err)
 	}
-	if !strings.Contains(string(data), "version: 999") {
-		t.Errorf("expected YAML to contain 'version: 999', got:\n%s", string(data))
+	if !strings.Contains(string(data), `version: "1.0"`) {
+		t.Errorf("expected YAML to contain 'version: \"1.0\"', got:\n%s", string(data))
 	}
 }
 
-func TestValidateSchema_NegativeVersionRejected(t *testing.T) {
-	schema := &TypeSchema{
-		Name:    "bad",
-		Version: -1,
-	}
-	errs := ValidateSchema(schema)
-	if len(errs) != 1 {
-		t.Fatalf("expected 1 error for negative version, got %d: %v", len(errs), errs)
-	}
-	if !strings.Contains(errs[0].Error(), "non-negative") {
-		t.Errorf("expected error mentioning 'non-negative', got %q", errs[0].Error())
-	}
-}
-
-func TestValidateSchema_ZeroVersionAccepted(t *testing.T) {
-	schema := &TypeSchema{
-		Name:    "book",
-		Version: 0,
-		Properties: []Property{
-			{Name: "title", Type: "string"},
-		},
-	}
-	errs := ValidateSchema(schema)
-	if len(errs) != 0 {
-		t.Errorf("expected no errors for version 0, got %v", errs)
+func TestValidateSchema_ValidVersionAccepted(t *testing.T) {
+	tests := []string{"0.0", "1.0", "2.3", "10.99"}
+	for _, v := range tests {
+		schema := &TypeSchema{
+			Name:    "book",
+			Version: v,
+			Properties: []Property{
+				{Name: "title", Type: "string"},
+			},
+		}
+		errs := ValidateSchema(schema)
+		if len(errs) != 0 {
+			t.Errorf("expected no errors for version %q, got %v", v, errs)
+		}
 	}
 }
 
-func TestValidateSchema_PositiveVersionAccepted(t *testing.T) {
-	schema := &TypeSchema{
-		Name:    "book",
-		Version: 5,
-		Properties: []Property{
-			{Name: "title", Type: "string"},
-		},
+func TestValidateSchema_InvalidVersionRejected(t *testing.T) {
+	tests := []struct {
+		version string
+		desc    string
+	}{
+		{"1", "single number"},
+		{"1.0.0", "three segments"},
+		{"01.0", "leading zero in major"},
+		{"0.01", "leading zero in minor"},
+		{"-1.0", "negative major"},
+		{"abc", "non-numeric"},
+		{"1.x", "non-numeric minor"},
 	}
-	errs := ValidateSchema(schema)
-	if len(errs) != 0 {
-		t.Errorf("expected no errors for version 5, got %v", errs)
+	for _, tc := range tests {
+		schema := &TypeSchema{Name: "bad", Version: tc.version}
+		errs := ValidateSchema(schema)
+		found := false
+		for _, err := range errs {
+			if strings.Contains(err.Error(), "major.minor") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("version %q (%s): expected error mentioning 'major.minor', got %v", tc.version, tc.desc, errs)
+		}
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"2.0", "1.3", 1},
+		{"1.2", "1.1", 1},
+		{"1.1", "1.1", 0},
+		{"0.1", "1.0", -1},
+		{"0.0", "0.0", 0},
+		{"0.0", "0.1", -1},
+		{"10.0", "9.99", 1},
+	}
+	for _, tc := range tests {
+		got := CompareVersions(tc.a, tc.b)
+		if got != tc.want {
+			t.Errorf("CompareVersions(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
 	}
 }
 

--- a/openspec/specs/type-schema/spec.md
+++ b/openspec/specs/type-schema/spec.md
@@ -291,43 +291,87 @@ After resolving all `use` entries, the type schema SHALL NOT have duplicate prop
 
 ### Requirement: Type schema supports optional version field
 
-The TypeSchema struct SHALL support an optional `version` field that stores a non-negative integer value. When a type schema YAML file includes a `version` field, it SHALL be parsed and stored. When the field is omitted, the version SHALL default to `0` (meaning "unversioned"). The version field provides a foundation for future schema migration tracking.
+The TypeSchema struct SHALL support an optional `version` field that stores a semver-style `"major.minor"` string value. Major indicates breaking changes; minor indicates backward-compatible changes. When a type schema YAML file includes a `version` field, it SHALL be parsed and stored as a string. When the field is omitted, the version SHALL default to `"0.0"` (meaning "unversioned"). The version field provides a foundation for future schema migration tracking.
 
 #### Scenario: Type schema with version defined
 
-- **WHEN** a type schema YAML file contains `version: 1`
-- **THEN** the loaded TypeSchema SHALL have its Version field set to 1
+- **WHEN** a type schema YAML file contains `version: "1.0"`
+- **THEN** the loaded TypeSchema SHALL have its Version field set to "1.0"
 
 #### Scenario: Type schema without version defined
 
 - **WHEN** a type schema YAML file does not contain a `version` field
-- **THEN** the loaded TypeSchema SHALL have its Version field set to 0
+- **THEN** the loaded TypeSchema SHALL have its Version field set to "0.0"
 
-#### Scenario: Version zero omitted from YAML output
+#### Scenario: Default version omitted from YAML output
 
-- **WHEN** a TypeSchema with Version 0 is serialized to YAML
+- **WHEN** a TypeSchema with Version "0.0" is serialized to YAML
 - **THEN** the output SHALL NOT contain a `version:` line
 
-#### Scenario: Positive version included in YAML output
+#### Scenario: Non-default version included in YAML output
 
-- **WHEN** a TypeSchema with Version 1 is serialized to YAML
-- **THEN** the output SHALL contain `version: 1`
+- **WHEN** a TypeSchema with Version "1.0" is serialized to YAML
+- **THEN** the output SHALL contain `version: "1.0"`
 
-### Requirement: Version must be non-negative
+### Requirement: Version format must be valid major.minor
 
-Schema validation SHALL reject negative version values. Zero and positive integers are accepted.
+Schema validation SHALL enforce the `"major.minor"` format. Both major and minor SHALL be non-negative integers without leading zeros. An empty string SHALL be treated as `"0.0"`.
 
-#### Scenario: Positive version accepted
+#### Scenario: Valid version accepted
 
-- **WHEN** a type schema has `version: 3`
+- **WHEN** a type schema has `version: "2.3"`
 - **THEN** schema validation SHALL accept without error
 
 #### Scenario: Zero version accepted
 
-- **WHEN** a type schema has `version: 0`
+- **WHEN** a type schema has `version: "0.0"`
 - **THEN** schema validation SHALL accept without error
 
-#### Scenario: Negative version rejected
+#### Scenario: Single number rejected
 
-- **WHEN** a type schema has `version: -1`
-- **THEN** schema validation SHALL return an error indicating version must be non-negative
+- **WHEN** a type schema has `version: "1"`
+- **THEN** schema validation SHALL return an error indicating version must be in "major.minor" format
+
+#### Scenario: Three segments rejected
+
+- **WHEN** a type schema has `version: "1.0.0"`
+- **THEN** schema validation SHALL return an error indicating version must be in "major.minor" format
+
+#### Scenario: Leading zeros rejected
+
+- **WHEN** a type schema has `version: "01.0"`
+- **THEN** schema validation SHALL return an error indicating version must be in "major.minor" format
+
+#### Scenario: Negative numbers rejected
+
+- **WHEN** a type schema has `version: "-1.0"`
+- **THEN** schema validation SHALL return an error indicating version must be in "major.minor" format
+
+#### Scenario: Non-numeric values rejected
+
+- **WHEN** a type schema has `version: "abc"`
+- **THEN** schema validation SHALL return an error indicating version must be in "major.minor" format
+
+### Requirement: Version comparison
+
+A `CompareVersions(a, b string)` function SHALL compare two version strings. It SHALL compare major first, then minor. It SHALL return -1 if a < b, 0 if a == b, and 1 if a > b.
+
+#### Scenario: Higher major is greater
+
+- **WHEN** comparing version "2.0" with "1.3"
+- **THEN** CompareVersions SHALL return 1
+
+#### Scenario: Higher minor is greater
+
+- **WHEN** comparing version "1.2" with "1.1"
+- **THEN** CompareVersions SHALL return 1
+
+#### Scenario: Equal versions
+
+- **WHEN** comparing version "1.1" with "1.1"
+- **THEN** CompareVersions SHALL return 0
+
+#### Scenario: Lower version is less
+
+- **WHEN** comparing version "0.1" with "1.0"
+- **THEN** CompareVersions SHALL return -1

--- a/websites/docs/src/content/docs/concepts/types.md
+++ b/websites/docs/src/content/docs/concepts/types.md
@@ -36,7 +36,7 @@ The optional `plural` field provides a grammatically correct display name for th
 
 The optional `emoji` field provides a visual icon for the type in CLI and TUI output.
 
-The optional `version` field is a non-negative integer for tracking schema evolution (e.g., `version: 1`). When omitted, it defaults to 0 (unversioned). You can manually increment this when making breaking changes to a type schema, providing a foundation for future migration tooling.
+The optional `version` field is a semver-style `"major.minor"` string for tracking schema evolution (e.g., `version: "1.0"`). When omitted, it defaults to `"0.0"` (unversioned). Increment the major number for breaking changes, and the minor number for backward-compatible changes, providing a foundation for future migration tooling.
 
 ## Why Types matter
 


### PR DESCRIPTION
## Summary

- Add `version` field (semver-style `"major.minor"` string, default `"0.0"`) to TypeSchema for tracking schema evolution
- Major indicates breaking changes, minor indicates backward-compatible changes
- Validate format in `ValidateSchema()`, omit from YAML when `"0.0"` (`omitempty`)
- Add `CompareVersions()` for version comparison and `DefaultSchemaVersion` constant
- 15 BDD scenarios + table-driven unit tests covering serialization, validation, and comparison
- Update CLAUDE.md, OpenSpec spec, docs site, README, and README.zh-TW

## Issue

Closes #45

## Test Plan

- [x] `go test ./...` — all pass (core, cmd, mcp, tui)
- [x] `go build ./...` — clean build
- [x] Manual: existing schemas without `version` load correctly with Version="0.0"
- [x] Manual: schema with `version: "1.0"` round-trips through save/load
- [x] Manual: invalid formats (`"1"`, `"1.0.0"`, `"01.0"`, `"-1.0"`, `"abc"`) rejected by validation