### PR TITLE
feat(core,cmd): add tmd stats command for aggregate statistics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,7 @@ graph LR
 | `domain_event.go` | Domain event types + EventDispatcher |
 | `vault.go` | Vault facade + lifecycle (Open/Close/Init) |
 | `type_schema.go` | TypeSchema entity + validation + YAML serialization + version handling (DefaultSchemaVersion, CompareVersions) + color validation (ValidColorPresets, validateColor) + Vault type CRUD (SaveType/DeleteType/CountObjectsByType) |
+| `stats.go` | VaultStats/TypeSummary/TypeStats/PropertyStats structs + QueryService.VaultStats()/TypeStats() methods + TypeSummary.DisplayName() |
 | `doctor.go` | Doctor health check: RunDoctor orchestrator, DoctorReport, issue categories |
 | `doctor_orphan.go` | OrphanDir scanning for objects/ and templates/ without type schemas |
 | `starters.go` | Embedded starter type templates (idea/note/book) + StarterTypes() + Vault.WriteStarterTypes() |

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ tmd type validate
 # Comprehensive vault health check (superset of validate)
 tmd doctor
 
+# Vault-wide statistics summary
+tmd stats                # vault-wide summary
+tmd stats --type book    # per-type property stats
+tmd stats --json         # JSON output
+
 # Manage vault configuration
 tmd config set cli.default_type idea
 tmd config get cli.default_type

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -126,6 +126,11 @@ tmd --reindex
 # 驗證 schema、Object 和 Relation
 tmd type validate
 
+# Vault 統計摘要
+tmd stats                # 整體統計摘要
+tmd stats --type book    # 指定 Type 的屬性統計
+tmd stats --json         # JSON 輸出
+
 # 管理 vault 設定
 tmd config set cli.default_type idea
 tmd config get cli.default_type

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -40,18 +40,23 @@ func openVault(path string, reindex bool) (*core.Vault, error) {
 	return vault, nil
 }
 
+// printJSON marshals any value as indented JSON and prints it.
+func printJSON(v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal JSON: %w", err)
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
 // printObjects prints objects as JSON or one DisplayID per line.
 func printObjects(objects []*core.Object, asJSON bool) error {
 	if asJSON {
-		data, err := json.MarshalIndent(objects, "", "  ")
-		if err != nil {
-			return fmt.Errorf("marshal JSON: %w", err)
-		}
-		fmt.Println(string(data))
-	} else {
-		for _, obj := range objects {
-			fmt.Printf("%s/%s\n", obj.Type, obj.GetName())
-		}
+		return printJSON(objects)
+	}
+	for _, obj := range objects {
+		fmt.Printf("%s/%s\n", obj.Type, obj.GetName())
 	}
 	return nil
 }

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/typemd/typemd/core"
+)
+
+var statsTypeName string
+var statsJSON bool
+
+var statsCmd = &cobra.Command{
+	Use:   "stats",
+	Short: "Show aggregate statistics about the vault",
+	Long: `Show aggregate statistics about the vault.
+
+Without flags, displays a per-type summary with object counts.
+With --type, displays per-property aggregations for a specific type.
+
+Examples:
+  tmd stats
+  tmd stats --type book
+  tmd stats --type book --json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		vault, err := openVault(vaultPath, reindex)
+		if err != nil {
+			return err
+		}
+		defer vault.Close()
+
+		if statsTypeName != "" {
+			return runTypeStats(vault, statsTypeName, statsJSON)
+		}
+		return runVaultStats(vault, statsJSON)
+	},
+}
+
+func runVaultStats(vault *core.Vault, asJSON bool) error {
+	stats, err := vault.VaultStats()
+	if err != nil {
+		return err
+	}
+
+	if asJSON {
+		return printJSON(stats)
+	}
+
+	if len(stats.Types) == 0 {
+		fmt.Println("No objects in vault.")
+		return nil
+	}
+
+	// Find max name length for alignment
+	maxLen := 0
+	for _, ts := range stats.Types {
+		name := ts.DisplayName()
+		if len(name) > maxLen {
+			maxLen = len(name)
+		}
+	}
+
+	for _, ts := range stats.Types {
+		emoji := ts.Emoji
+		if emoji == "" {
+			emoji = " "
+		}
+
+		lastUpdated := ""
+		if !ts.LastUpdated.IsZero() {
+			lastUpdated = fmt.Sprintf("   last updated %s", ts.LastUpdated.Format("2006-01-02"))
+		}
+
+		fmt.Printf("%s %-*s  %3d%s\n", emoji, maxLen, ts.DisplayName(), ts.Count, lastUpdated)
+	}
+
+	fmt.Println(strings.Repeat("─", maxLen+20))
+	fmt.Printf("  %-*s  %3d\n", maxLen, "Total", stats.Total)
+
+	return nil
+}
+
+func runTypeStats(vault *core.Vault, typeName string, asJSON bool) error {
+	stats, err := vault.TypeStats(typeName)
+	if err != nil {
+		return err
+	}
+
+	if asJSON {
+		return printJSON(stats)
+	}
+
+	emoji := ""
+	if stats.Emoji != "" {
+		emoji = stats.Emoji + " "
+	}
+
+	fmt.Printf("%s%s (%d objects)\n", emoji, typeName, stats.Count)
+	fmt.Println(strings.Repeat("─", 40))
+
+	if len(stats.Properties) == 0 {
+		fmt.Println("No properties defined.")
+		return nil
+	}
+
+	for _, ps := range stats.Properties {
+		fmt.Println()
+		fmt.Printf("%s (%s)\n", ps.Name, ps.Type)
+		fmt.Printf("  filled: %d/%d\n", ps.Filled, ps.Total)
+
+		if ps.Stats == nil {
+			continue
+		}
+
+		switch s := ps.Stats.(type) {
+		case *core.NumberStats:
+			fmt.Printf("  sum: %g  avg: %g  min: %g  max: %g\n", s.Sum, s.Avg, s.Min, s.Max)
+		case *core.SelectStats:
+			for option, count := range s.Distribution {
+				bar := strings.Repeat("█", count)
+				fmt.Printf("  %-15s %s %d\n", option, bar, count)
+			}
+		case *core.CheckboxStats:
+			fmt.Printf("  true: %d  false: %d\n", s.TrueCount, s.FalseCount)
+		case *core.DateStats:
+			fmt.Printf("  earliest: %s  latest: %s\n", s.Earliest, s.Latest)
+		case *core.RelationStats:
+			fmt.Printf("  links: %d\n", s.Count)
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	statsCmd.Flags().StringVar(&statsTypeName, "type", "", "Show stats for a specific type")
+	statsCmd.Flags().BoolVar(&statsJSON, "json", false, "Output as JSON")
+	rootCmd.AddCommand(statsCmd)
+}

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -1,0 +1,212 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/typemd/typemd/core"
+)
+
+func setupStatsVault(t *testing.T) (*core.Vault, string) {
+	t.Helper()
+	dir := t.TempDir()
+	v := core.NewVault(dir)
+	if err := v.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	// Write book type schema
+	typesDir := filepath.Join(dir, ".typemd", "types")
+	os.WriteFile(filepath.Join(typesDir, "book.yaml"), []byte(`name: book
+emoji: "📚"
+plural: books
+properties:
+  - name: rating
+    type: number
+  - name: status
+    type: select
+    options:
+      - value: reading
+      - value: done
+`), 0644)
+
+	if err := v.Open(); err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+
+	return v, dir
+}
+
+func resetStatsFlags() {
+	statsTypeName = ""
+	statsJSON = false
+}
+
+func TestStatsCmd_VaultWide(t *testing.T) {
+	resetStatsFlags()
+	v, dir := setupStatsVault(t)
+
+	// Create some objects
+	if _, err := v.NewObject("book", "book1", ""); err != nil {
+		t.Fatalf("NewObject error = %v", err)
+	}
+	if _, err := v.NewObject("book", "book2", ""); err != nil {
+		t.Fatalf("NewObject error = %v", err)
+	}
+	v.Close()
+
+	vaultPath = dir
+	rootCmd.SetArgs([]string{"stats"})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(output, "books") {
+		t.Errorf("expected 'books' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "2") {
+		t.Errorf("expected count '2' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Total") {
+		t.Errorf("expected 'Total' in output, got:\n%s", output)
+	}
+}
+
+func TestStatsCmd_SingleType(t *testing.T) {
+	resetStatsFlags()
+	v, dir := setupStatsVault(t)
+
+	obj, err := v.NewObject("book", "book1", "")
+	if err != nil {
+		t.Fatalf("NewObject error = %v", err)
+	}
+	if err := v.SetProperty(obj.ID, "rating", float64(4)); err != nil {
+		t.Fatalf("SetProperty error = %v", err)
+	}
+	v.Close()
+
+	vaultPath = dir
+	rootCmd.SetArgs([]string{"stats", "--type", "book"})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err = rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(output, "book (1 objects)") {
+		t.Errorf("expected 'book (1 objects)' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "rating") {
+		t.Errorf("expected 'rating' in output, got:\n%s", output)
+	}
+}
+
+func TestStatsCmd_JSON(t *testing.T) {
+	resetStatsFlags()
+	v, dir := setupStatsVault(t)
+	if _, err := v.NewObject("book", "book1", ""); err != nil {
+		t.Fatalf("NewObject error = %v", err)
+	}
+	v.Close()
+
+	vaultPath = dir
+	rootCmd.SetArgs([]string{"stats", "--json"})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(output, `"Total"`) && !strings.Contains(output, `"total"`) {
+		// JSON output should have structured data
+		if !strings.Contains(output, "{") {
+			t.Errorf("expected JSON output, got:\n%s", output)
+		}
+	}
+}
+
+func TestStatsCmd_NonExistentType(t *testing.T) {
+	resetStatsFlags()
+	v, dir := setupStatsVault(t)
+	v.Close()
+
+	vaultPath = dir
+	rootCmd.SetArgs([]string{"stats", "--type", "nonexistent"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for non-existent type")
+	}
+	if !strings.Contains(err.Error(), "nonexistent") {
+		t.Errorf("error = %q, expected to mention 'nonexistent'", err)
+	}
+}
+
+func TestStatsCmd_EmptyVault(t *testing.T) {
+	resetStatsFlags()
+	dir := t.TempDir()
+	v := core.NewVault(dir)
+	if err := v.Init(); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	v.Close()
+
+	vaultPath = dir
+	rootCmd.SetArgs([]string{"stats"})
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := rootCmd.Execute()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(output, "No objects") {
+		t.Errorf("expected 'No objects' message, got:\n%s", output)
+	}
+}

--- a/core/bdd_steps_stats_test.go
+++ b/core/bdd_steps_stats_test.go
@@ -1,0 +1,403 @@
+package core
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/cucumber/godog"
+)
+
+// ── Stats test context ──────────────────────────────────────────────────────
+
+type statsContext struct {
+	vaultStats *VaultStats
+	typeStats  *TypeStats
+}
+
+func newStatsContext() *statsContext {
+	return &statsContext{}
+}
+
+// ── Setup steps ─────────────────────────────────────────────────────────────
+
+func (sc *statsContext) aTypeWithACheckboxPropertyExists(dc *domainContext, typeName, propName string) {
+	yaml := fmt.Sprintf("name: %s\nproperties:\n  - name: %s\n    type: checkbox\n", typeName, propName)
+	path := filepath.Join(dc.vault.TypesDir(), typeName+".yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		panic(fmt.Sprintf("write type schema: %v", err))
+	}
+}
+
+func (sc *statsContext) aTypeWithADatePropertyExists(dc *domainContext, typeName, propName string) {
+	yaml := fmt.Sprintf("name: %s\nproperties:\n  - name: %s\n    type: date\n", typeName, propName)
+	path := filepath.Join(dc.vault.TypesDir(), typeName+".yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		panic(fmt.Sprintf("write type schema: %v", err))
+	}
+}
+
+func (sc *statsContext) aTypeWithARelationPropertyExists(dc *domainContext, typeName, propName, target string) {
+	yaml := fmt.Sprintf("name: %s\nproperties:\n  - name: %s\n    type: relation\n    target: %s\n", typeName, propName, target)
+	path := filepath.Join(dc.vault.TypesDir(), typeName+".yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0644); err != nil {
+		panic(fmt.Sprintf("write type schema: %v", err))
+	}
+}
+
+func (sc *statsContext) aObjectNamedExistsWithTypedProperty(dc *domainContext, typeName, name, prop, value string) {
+	dc.aObjectNamedExists(typeName, name)
+	schema, err := dc.vault.LoadType(typeName)
+	if err != nil {
+		panic(fmt.Sprintf("load type schema: %v", err))
+	}
+	// Find property type and coerce value
+	var typedValue any = value
+	for _, p := range schema.Properties {
+		if p.Name == prop {
+			switch p.Type {
+			case "number":
+				f, err := strconv.ParseFloat(value, 64)
+				if err != nil {
+					panic(fmt.Sprintf("parse float: %v", err))
+				}
+				typedValue = f
+			case "checkbox":
+				b, err := strconv.ParseBool(value)
+				if err != nil {
+					panic(fmt.Sprintf("parse bool: %v", err))
+				}
+				typedValue = b
+			}
+			break
+		}
+	}
+	if err := dc.vault.SetProperty(dc.currentObject.ID, prop, typedValue); err != nil {
+		panic(fmt.Sprintf("SetProperty failed: %v", err))
+	}
+}
+
+// ── VaultStats steps ────────────────────────────────────────────────────────
+
+func (sc *statsContext) iRequestVaultStats(dc *domainContext) {
+	stats, err := dc.vault.VaultStats()
+	dc.lastErr = err
+	sc.vaultStats = stats
+}
+
+func (sc *statsContext) theVaultStatsShouldShowNTypes(expected int) error {
+	if sc.vaultStats == nil {
+		return fmt.Errorf("vault stats is nil")
+	}
+	if len(sc.vaultStats.Types) != expected {
+		return fmt.Errorf("type count = %d, want %d", len(sc.vaultStats.Types), expected)
+	}
+	return nil
+}
+
+func (sc *statsContext) theVaultStatsTotalShouldBe(expected int) error {
+	if sc.vaultStats == nil {
+		return fmt.Errorf("vault stats is nil")
+	}
+	if sc.vaultStats.Total != expected {
+		return fmt.Errorf("total = %d, want %d", sc.vaultStats.Total, expected)
+	}
+	return nil
+}
+
+func (sc *statsContext) theVaultStatsForTypeShouldShowCount(typeName string, expected int) error {
+	if sc.vaultStats == nil {
+		return fmt.Errorf("vault stats is nil")
+	}
+	for _, ts := range sc.vaultStats.Types {
+		if ts.Name == typeName {
+			if ts.Count != expected {
+				return fmt.Errorf("type %q count = %d, want %d", typeName, ts.Count, expected)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("type %q not found in vault stats", typeName)
+}
+
+func (sc *statsContext) theVaultStatsForTypeShouldShowEmoji(typeName, expected string) error {
+	if sc.vaultStats == nil {
+		return fmt.Errorf("vault stats is nil")
+	}
+	for _, ts := range sc.vaultStats.Types {
+		if ts.Name == typeName {
+			if ts.Emoji != expected {
+				return fmt.Errorf("type %q emoji = %q, want %q", typeName, ts.Emoji, expected)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("type %q not found in vault stats", typeName)
+}
+
+// ── TypeStats steps ─────────────────────────────────────────────────────────
+
+func (sc *statsContext) iRequestTypeStats(dc *domainContext, typeName string) {
+	stats, err := dc.vault.TypeStats(typeName)
+	dc.lastErr = err
+	sc.typeStats = stats
+}
+
+func (sc *statsContext) theTypeStatsShouldShowCount(expected int) error {
+	if sc.typeStats == nil {
+		return fmt.Errorf("type stats is nil")
+	}
+	if sc.typeStats.Count != expected {
+		return fmt.Errorf("count = %d, want %d", sc.typeStats.Count, expected)
+	}
+	return nil
+}
+
+func (sc *statsContext) findProperty(propName string) (*PropertyStats, error) {
+	if sc.typeStats == nil {
+		return nil, fmt.Errorf("type stats is nil")
+	}
+	for i, ps := range sc.typeStats.Properties {
+		if ps.Name == propName {
+			return &sc.typeStats.Properties[i], nil
+		}
+	}
+	return nil, fmt.Errorf("property %q not found in type stats", propName)
+}
+
+func (sc *statsContext) theTypeStatsPropertyShouldHaveType(propName, expected string) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	if ps.Type != expected {
+		return fmt.Errorf("property %q type = %q, want %q", propName, ps.Type, expected)
+	}
+	return nil
+}
+
+func (sc *statsContext) theTypeStatsPropertyShouldShowFilled(propName string, expected int) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	if ps.Filled != expected {
+		return fmt.Errorf("property %q filled = %d, want %d", propName, ps.Filled, expected)
+	}
+	return nil
+}
+
+// Number stats assertions
+func (sc *statsContext) theTypeStatsPropertyNumberAvg(propName string, expected float64) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	ns, ok := ps.Stats.(*NumberStats)
+	if !ok {
+		return fmt.Errorf("property %q stats is not NumberStats (got %T)", propName, ps.Stats)
+	}
+	if ns.Avg != expected {
+		return fmt.Errorf("property %q avg = %v, want %v", propName, ns.Avg, expected)
+	}
+	return nil
+}
+
+func (sc *statsContext) theTypeStatsPropertyNumberMin(propName string, expected float64) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	ns, ok := ps.Stats.(*NumberStats)
+	if !ok {
+		return fmt.Errorf("property %q stats is not NumberStats", propName)
+	}
+	if ns.Min != expected {
+		return fmt.Errorf("property %q min = %v, want %v", propName, ns.Min, expected)
+	}
+	return nil
+}
+
+func (sc *statsContext) theTypeStatsPropertyNumberMax(propName string, expected float64) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	ns, ok := ps.Stats.(*NumberStats)
+	if !ok {
+		return fmt.Errorf("property %q stats is not NumberStats", propName)
+	}
+	if ns.Max != expected {
+		return fmt.Errorf("property %q max = %v, want %v", propName, ns.Max, expected)
+	}
+	return nil
+}
+
+func (sc *statsContext) theTypeStatsPropertyNumberSum(propName string, expected float64) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	ns, ok := ps.Stats.(*NumberStats)
+	if !ok {
+		return fmt.Errorf("property %q stats is not NumberStats", propName)
+	}
+	if ns.Sum != expected {
+		return fmt.Errorf("property %q sum = %v, want %v", propName, ns.Sum, expected)
+	}
+	return nil
+}
+
+// Select stats assertions
+func (sc *statsContext) theTypeStatsPropertySelectCount(propName, option string, expected int) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	ss, ok := ps.Stats.(*SelectStats)
+	if !ok {
+		return fmt.Errorf("property %q stats is not SelectStats (got %T)", propName, ps.Stats)
+	}
+	count, exists := ss.Distribution[option]
+	if !exists {
+		return fmt.Errorf("property %q option %q not found in distribution", propName, option)
+	}
+	if count != expected {
+		return fmt.Errorf("property %q option %q count = %d, want %d", propName, option, count, expected)
+	}
+	return nil
+}
+
+// Checkbox stats assertions
+func (sc *statsContext) theTypeStatsPropertyCheckboxTrueCount(propName string, expected int) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	cs, ok := ps.Stats.(*CheckboxStats)
+	if !ok {
+		return fmt.Errorf("property %q stats is not CheckboxStats (got %T)", propName, ps.Stats)
+	}
+	if cs.TrueCount != expected {
+		return fmt.Errorf("property %q true count = %d, want %d", propName, cs.TrueCount, expected)
+	}
+	return nil
+}
+
+func (sc *statsContext) theTypeStatsPropertyCheckboxFalseCount(propName string, expected int) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	cs, ok := ps.Stats.(*CheckboxStats)
+	if !ok {
+		return fmt.Errorf("property %q stats is not CheckboxStats", propName)
+	}
+	if cs.FalseCount != expected {
+		return fmt.Errorf("property %q false count = %d, want %d", propName, cs.FalseCount, expected)
+	}
+	return nil
+}
+
+// Date stats assertions
+func (sc *statsContext) theTypeStatsPropertyDateEarliest(propName, expected string) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	ds, ok := ps.Stats.(*DateStats)
+	if !ok {
+		return fmt.Errorf("property %q stats is not DateStats (got %T)", propName, ps.Stats)
+	}
+	if ds.Earliest != expected {
+		return fmt.Errorf("property %q earliest = %q, want %q", propName, ds.Earliest, expected)
+	}
+	return nil
+}
+
+func (sc *statsContext) theTypeStatsPropertyDateLatest(propName, expected string) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	ds, ok := ps.Stats.(*DateStats)
+	if !ok {
+		return fmt.Errorf("property %q stats is not DateStats", propName)
+	}
+	if ds.Latest != expected {
+		return fmt.Errorf("property %q latest = %q, want %q", propName, ds.Latest, expected)
+	}
+	return nil
+}
+
+// Relation stats assertions
+func (sc *statsContext) theTypeStatsPropertyRelationCount(propName string, expected int) error {
+	ps, err := sc.findProperty(propName)
+	if err != nil {
+		return err
+	}
+	rs, ok := ps.Stats.(*RelationStats)
+	if !ok {
+		return fmt.Errorf("property %q stats is not RelationStats (got %T)", propName, ps.Stats)
+	}
+	if rs.Count != expected {
+		return fmt.Errorf("property %q relation count = %d, want %d", propName, rs.Count, expected)
+	}
+	return nil
+}
+
+// ── Step registration ───────────────────────────────────────────────────────
+
+func initStatsSteps(ctx *godog.ScenarioContext, dc *domainContext) {
+	sc := newStatsContext()
+
+	// Setup steps
+	ctx.Step(`^a type "([^"]*)" with a "([^"]*)" checkbox property exists$`, func(typeName, propName string) {
+		sc.aTypeWithACheckboxPropertyExists(dc, typeName, propName)
+	})
+	ctx.Step(`^a type "([^"]*)" with a "([^"]*)" date property exists$`, func(typeName, propName string) {
+		sc.aTypeWithADatePropertyExists(dc, typeName, propName)
+	})
+	ctx.Step(`^a type "([^"]*)" with an "([^"]*)" relation to "([^"]*)" exists$`, func(typeName, propName, target string) {
+		sc.aTypeWithARelationPropertyExists(dc, typeName, propName, target)
+	})
+
+	// Typed property setup
+	ctx.Step(`^a "([^"]*)" object named "([^"]*)" exists with typed property "([^"]*)" set to "([^"]*)"$`, func(typeName, name, prop, value string) {
+		sc.aObjectNamedExistsWithTypedProperty(dc, typeName, name, prop, value)
+	})
+
+	// VaultStats steps
+	ctx.Step(`^I request vault stats$`, func() { sc.iRequestVaultStats(dc) })
+	ctx.Step(`^the vault stats should show (\d+) types?$`, sc.theVaultStatsShouldShowNTypes)
+	ctx.Step(`^the vault stats total should be (\d+)$`, sc.theVaultStatsTotalShouldBe)
+	ctx.Step(`^the vault stats for type "([^"]*)" should show count (\d+)$`, sc.theVaultStatsForTypeShouldShowCount)
+	ctx.Step(`^the vault stats for type "([^"]*)" should show emoji "([^"]*)"$`, sc.theVaultStatsForTypeShouldShowEmoji)
+
+	// TypeStats steps
+	ctx.Step(`^I request type stats for "([^"]*)"$`, func(typeName string) { sc.iRequestTypeStats(dc, typeName) })
+	ctx.Step(`^the type stats should show count (\d+)$`, sc.theTypeStatsShouldShowCount)
+	ctx.Step(`^the type stats property "([^"]*)" should have type "([^"]*)"$`, sc.theTypeStatsPropertyShouldHaveType)
+	ctx.Step(`^the type stats property "([^"]*)" should show filled (\d+)$`, sc.theTypeStatsPropertyShouldShowFilled)
+
+	// Number
+	ctx.Step(`^the type stats property "([^"]*)" number avg should be (\d+(?:\.\d+)?)$`, sc.theTypeStatsPropertyNumberAvg)
+	ctx.Step(`^the type stats property "([^"]*)" number min should be (\d+(?:\.\d+)?)$`, sc.theTypeStatsPropertyNumberMin)
+	ctx.Step(`^the type stats property "([^"]*)" number max should be (\d+(?:\.\d+)?)$`, sc.theTypeStatsPropertyNumberMax)
+	ctx.Step(`^the type stats property "([^"]*)" number sum should be (\d+(?:\.\d+)?)$`, sc.theTypeStatsPropertyNumberSum)
+
+	// Select
+	ctx.Step(`^the type stats property "([^"]*)" select "([^"]*)" should have count (\d+)$`, sc.theTypeStatsPropertySelectCount)
+
+	// Checkbox
+	ctx.Step(`^the type stats property "([^"]*)" checkbox true count should be (\d+)$`, sc.theTypeStatsPropertyCheckboxTrueCount)
+	ctx.Step(`^the type stats property "([^"]*)" checkbox false count should be (\d+)$`, sc.theTypeStatsPropertyCheckboxFalseCount)
+
+	// Date
+	ctx.Step(`^the type stats property "([^"]*)" date earliest should be "([^"]*)"$`, sc.theTypeStatsPropertyDateEarliest)
+	ctx.Step(`^the type stats property "([^"]*)" date latest should be "([^"]*)"$`, sc.theTypeStatsPropertyDateLatest)
+
+	// Relation
+	ctx.Step(`^the type stats property "([^"]*)" relation count should be (\d+)$`, sc.theTypeStatsPropertyRelationCount)
+}

--- a/core/bdd_test.go
+++ b/core/bdd_test.go
@@ -164,6 +164,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	initViewCrudSteps(ctx, dc, vcCtx)
 	initQuerySortSteps(ctx, dc)
 	initFilterOperatorSteps(ctx, dc)
+	initStatsSteps(ctx, dc)
 }
 
 func TestFeatures(t *testing.T) {

--- a/core/features/type_stats.feature
+++ b/core/features/type_stats.feature
@@ -1,0 +1,73 @@
+Feature: Type statistics
+  Users can view per-property aggregate statistics for a specific type.
+
+  Scenario: Number property aggregation
+    Given a vault is ready
+    And a "book" object named "book1" exists with typed property "rating" set to "3"
+    And a "book" object named "book2" exists with typed property "rating" set to "4"
+    And a "book" object named "book3" exists with typed property "rating" set to "5"
+    When I request type stats for "book"
+    Then the type stats should show count 3
+    And the type stats property "rating" should have type "number"
+    And the type stats property "rating" number avg should be 4.0
+    And the type stats property "rating" number min should be 3.0
+    And the type stats property "rating" number max should be 5.0
+    And the type stats property "rating" number sum should be 12.0
+    And the type stats property "rating" should show filled 3
+
+  Scenario: Select property distribution
+    Given a vault is ready
+    And a "book" object named "book1" exists with property "status" set to "reading"
+    And a "book" object named "book2" exists with property "status" set to "done"
+    And a "book" object named "book3" exists with property "status" set to "done"
+    When I request type stats for "book"
+    Then the type stats property "status" should have type "select"
+    And the type stats property "status" select "reading" should have count 1
+    And the type stats property "status" select "done" should have count 2
+
+  Scenario: Checkbox property ratio
+    Given a vault is ready
+    And a type "task" with a "completed" checkbox property exists
+    And a "task" object named "task1" exists with typed property "completed" set to "true"
+    And a "task" object named "task2" exists with typed property "completed" set to "true"
+    And a "task" object named "task3" exists with typed property "completed" set to "false"
+    When I request type stats for "task"
+    Then the type stats property "completed" should have type "checkbox"
+    And the type stats property "completed" checkbox true count should be 2
+    And the type stats property "completed" checkbox false count should be 1
+
+  Scenario: Date property range
+    Given a vault is ready
+    And a type "event" with a "date" date property exists
+    And a "event" object named "event1" exists with property "date" set to "2024-01-15"
+    And a "event" object named "event2" exists with property "date" set to "2024-06-20"
+    And a "event" object named "event3" exists with property "date" set to "2024-03-10"
+    When I request type stats for "event"
+    Then the type stats property "date" should have type "date"
+    And the type stats property "date" date earliest should be "2024-01-15"
+    And the type stats property "date" date latest should be "2024-06-20"
+
+  Scenario: Relation property count
+    Given a vault is ready
+    And a type "book" with an "author" relation to "person" exists
+    And a "person" object named "alice" exists
+    And a "person" object named "bob" exists
+    And a "book" object named "book1" exists
+    And I link "book1" to "alice" via "author"
+    And a "book" object named "book2" exists
+    And I link "book2" to "bob" via "author"
+    When I request type stats for "book"
+    Then the type stats property "author" should have type "relation"
+    And the type stats property "author" relation count should be 2
+
+  Scenario: Property with no values filled
+    Given a vault is ready
+    And a "book" object named "book1" exists
+    And a "book" object named "book2" exists
+    When I request type stats for "book"
+    Then the type stats property "rating" should show filled 0
+
+  Scenario: Non-existent type returns error
+    Given a vault is ready
+    When I request type stats for "nonexistent"
+    Then an error should occur

--- a/core/features/vault_stats.feature
+++ b/core/features/vault_stats.feature
@@ -1,0 +1,30 @@
+Feature: Vault statistics
+  Users can view aggregate statistics about their vault, including per-type
+  object counts and single-type property aggregations.
+
+  Scenario: Vault-wide stats with multiple types
+    Given a vault is ready
+    And a "book" object named "book1" exists
+    And a "book" object named "book2" exists
+    And a "book" object named "book3" exists
+    And a "person" object named "alice" exists
+    And a "person" object named "bob" exists
+    When I request vault stats
+    Then the vault stats should show 2 types
+    And the vault stats total should be 5
+    And the vault stats for type "book" should show count 3
+    And the vault stats for type "person" should show count 2
+
+  Scenario: Vault-wide stats on empty vault
+    Given a vault is ready
+    When I request vault stats
+    Then the vault stats should show 0 types
+    And the vault stats total should be 0
+
+  Scenario: Vault-wide stats includes built-in types
+    Given a vault is ready
+    And a "tag" object named "fiction" exists
+    When I request vault stats
+    Then the vault stats total should be 1
+    And the vault stats for type "tag" should show count 1
+    And the vault stats for type "tag" should show emoji "🏷️"

--- a/core/query.go
+++ b/core/query.go
@@ -96,6 +96,22 @@ func (v *Vault) SearchObjects(keyword string) ([]*Object, error) {
 	return v.Queries.Search(keyword)
 }
 
+// VaultStats returns aggregate statistics for all types. Delegates to QueryService.
+func (v *Vault) VaultStats() (*VaultStats, error) {
+	if v.Queries == nil {
+		return nil, fmt.Errorf("vault not opened")
+	}
+	return v.Queries.VaultStats()
+}
+
+// TypeStats returns per-property statistics for a type. Delegates to QueryService.
+func (v *Vault) TypeStats(typeName string) (*TypeStats, error) {
+	if v.Queries == nil {
+		return nil, fmt.Errorf("vault not opened")
+	}
+	return v.Queries.TypeStats(typeName)
+}
+
 // RebuildIndex rebuilds the FTS5 index.
 func (v *Vault) RebuildIndex() error {
 	if v.index == nil {

--- a/core/stats.go
+++ b/core/stats.go
@@ -1,0 +1,408 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+)
+
+// VaultStats holds aggregate statistics across all types.
+type VaultStats struct {
+	Types []TypeSummary `json:"types"`
+	Total int           `json:"total"`
+}
+
+// TypeSummary holds per-type summary information.
+type TypeSummary struct {
+	Name        string    `json:"name"`
+	Plural      string    `json:"plural,omitempty"`
+	Emoji       string    `json:"emoji,omitempty"`
+	Count       int       `json:"count"`
+	LastUpdated time.Time `json:"last_updated,omitempty"`
+}
+
+// DisplayName returns the plural name if set, otherwise the type name.
+func (ts TypeSummary) DisplayName() string {
+	if ts.Plural != "" {
+		return ts.Plural
+	}
+	return ts.Name
+}
+
+// TypeStats holds detailed property statistics for a single type.
+type TypeStats struct {
+	TypeName   string          `json:"type_name"`
+	Emoji      string          `json:"emoji,omitempty"`
+	Plural     string          `json:"plural,omitempty"`
+	Count      int             `json:"count"`
+	Properties []PropertyStats `json:"properties"`
+}
+
+// PropertyStats holds aggregated stats for a single property.
+type PropertyStats struct {
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Filled int    `json:"filled"`
+	Total  int    `json:"total"`
+	Stats  any    `json:"stats,omitempty"`
+}
+
+// NumberStats holds aggregation for number properties.
+type NumberStats struct {
+	Sum float64 `json:"sum"`
+	Avg float64 `json:"avg"`
+	Min float64 `json:"min"`
+	Max float64 `json:"max"`
+}
+
+// SelectStats holds frequency distribution for select/multi_select properties.
+type SelectStats struct {
+	Distribution map[string]int `json:"distribution"`
+}
+
+// CheckboxStats holds true/false counts for checkbox properties.
+type CheckboxStats struct {
+	TrueCount  int `json:"true_count"`
+	FalseCount int `json:"false_count"`
+}
+
+// DateStats holds earliest/latest for date/datetime properties.
+type DateStats struct {
+	Earliest string `json:"earliest"`
+	Latest   string `json:"latest"`
+}
+
+// RelationStats holds link counts for relation properties.
+type RelationStats struct {
+	Count int `json:"count"`
+}
+
+// VaultStats returns aggregate statistics for all types in the vault.
+func (s *QueryService) VaultStats() (*VaultStats, error) {
+	typeNames, err := s.repo.ListSchemas()
+	if err != nil {
+		return nil, fmt.Errorf("list types: %w", err)
+	}
+
+	stats := &VaultStats{}
+
+	for _, name := range typeNames {
+		results, err := s.index.Query("type=" + name)
+		if err != nil {
+			return nil, fmt.Errorf("query type %s: %w", name, err)
+		}
+		if len(results) == 0 {
+			continue
+		}
+
+		schema, _ := s.repo.GetSchema(name)
+		summary := TypeSummary{
+			Name:  name,
+			Count: len(results),
+		}
+		if schema != nil {
+			summary.Emoji = schema.Emoji
+			summary.Plural = schema.Plural
+		}
+
+		// Find latest updated_at
+		for _, r := range results {
+			if ua, ok := r.Properties[UpdatedAtProperty]; ok {
+				if uaStr, ok := ua.(string); ok {
+					if t, err := time.Parse(time.RFC3339, uaStr); err == nil {
+						if t.After(summary.LastUpdated) {
+							summary.LastUpdated = t
+						}
+					}
+				}
+			}
+		}
+
+		stats.Types = append(stats.Types, summary)
+		stats.Total += len(results)
+	}
+
+	sort.Slice(stats.Types, func(i, j int) bool {
+		return stats.Types[i].Name < stats.Types[j].Name
+	})
+
+	return stats, nil
+}
+
+// TypeStats returns per-property aggregate statistics for a single type.
+func (s *QueryService) TypeStats(typeName string) (*TypeStats, error) {
+	schema, err := s.repo.GetSchema(typeName)
+	if err != nil {
+		return nil, fmt.Errorf("load type %q: %w", typeName, err)
+	}
+
+	results, err := s.index.Query("type=" + typeName)
+	if err != nil {
+		return nil, fmt.Errorf("query type %s: %w", typeName, err)
+	}
+
+	objects := objectResultsToObjects(results)
+	ts := &TypeStats{
+		TypeName: typeName,
+		Emoji:    schema.Emoji,
+		Plural:   schema.Plural,
+		Count:    len(objects),
+	}
+
+	for _, prop := range schema.Properties {
+		ps := computePropertyStats(prop, objects)
+		ts.Properties = append(ts.Properties, ps)
+	}
+
+	return ts, nil
+}
+
+// computePropertyStats aggregates stats for a single property across objects.
+func computePropertyStats(prop Property, objects []*Object) PropertyStats {
+	ps := PropertyStats{
+		Name:  prop.Name,
+		Type:  prop.Type,
+		Total: len(objects),
+	}
+
+	switch prop.Type {
+	case "number":
+		if s := computeNumberStats(prop.Name, objects, &ps.Filled); s != nil {
+			ps.Stats = s
+		}
+	case "select":
+		if s := computeSelectStats(prop.Name, objects, &ps.Filled); s != nil {
+			ps.Stats = s
+		}
+	case "multi_select":
+		if s := computeMultiSelectStats(prop.Name, objects, &ps.Filled); s != nil {
+			ps.Stats = s
+		}
+	case "checkbox":
+		if s := computeCheckboxStats(prop.Name, objects, &ps.Filled); s != nil {
+			ps.Stats = s
+		}
+	case "date", "datetime":
+		if s := computeDateStats(prop.Name, objects, &ps.Filled); s != nil {
+			ps.Stats = s
+		}
+	case "relation":
+		if s := computeRelationStats(prop.Name, objects, &ps.Filled); s != nil {
+			ps.Stats = s
+		}
+	default:
+		// string, url — count filled only
+		for _, obj := range objects {
+			if v, ok := obj.Properties[prop.Name]; ok && v != nil && v != "" {
+				ps.Filled++
+			}
+		}
+	}
+
+	return ps
+}
+
+func computeNumberStats(propName string, objects []*Object, filled *int) *NumberStats {
+	var values []float64
+	for _, obj := range objects {
+		v, ok := obj.Properties[propName]
+		if !ok || v == nil {
+			continue
+		}
+		f, err := toFloat64(v)
+		if err != nil {
+			continue
+		}
+		values = append(values, f)
+	}
+	*filled = len(values)
+	if len(values) == 0 {
+		return nil
+	}
+
+	stats := &NumberStats{Min: values[0], Max: values[0]}
+	for _, v := range values {
+		stats.Sum += v
+		if v < stats.Min {
+			stats.Min = v
+		}
+		if v > stats.Max {
+			stats.Max = v
+		}
+	}
+	stats.Avg = stats.Sum / float64(len(values))
+	return stats
+}
+
+func computeSelectStats(propName string, objects []*Object, filled *int) *SelectStats {
+	dist := make(map[string]int)
+	for _, obj := range objects {
+		v, ok := obj.Properties[propName]
+		if !ok || v == nil {
+			continue
+		}
+		s := fmt.Sprintf("%v", v)
+		if s == "" {
+			continue
+		}
+		dist[s]++
+		*filled++
+	}
+	if len(dist) == 0 {
+		return nil
+	}
+	return &SelectStats{Distribution: dist}
+}
+
+func computeMultiSelectStats(propName string, objects []*Object, filled *int) *SelectStats {
+	dist := make(map[string]int)
+	for _, obj := range objects {
+		v, ok := obj.Properties[propName]
+		if !ok || v == nil {
+			continue
+		}
+		switch val := v.(type) {
+		case []any:
+			if len(val) == 0 {
+				continue
+			}
+			*filled++
+			for _, item := range val {
+				dist[fmt.Sprintf("%v", item)]++
+			}
+		case []string:
+			if len(val) == 0 {
+				continue
+			}
+			*filled++
+			for _, item := range val {
+				dist[item]++
+			}
+		default:
+			s := fmt.Sprintf("%v", v)
+			if s != "" {
+				dist[s]++
+				*filled++
+			}
+		}
+	}
+	if len(dist) == 0 {
+		return nil
+	}
+	return &SelectStats{Distribution: dist}
+}
+
+func computeCheckboxStats(propName string, objects []*Object, filled *int) *CheckboxStats {
+	stats := &CheckboxStats{}
+	for _, obj := range objects {
+		v, ok := obj.Properties[propName]
+		if !ok || v == nil {
+			continue
+		}
+		b, err := toBool(v)
+		if err != nil {
+			continue
+		}
+		*filled++
+		if b {
+			stats.TrueCount++
+		} else {
+			stats.FalseCount++
+		}
+	}
+	if *filled == 0 {
+		return nil
+	}
+	return stats
+}
+
+func computeDateStats(propName string, objects []*Object, filled *int) *DateStats {
+	var earliest, latest string
+	for _, obj := range objects {
+		v, ok := obj.Properties[propName]
+		if !ok || v == nil {
+			continue
+		}
+		s := fmt.Sprintf("%v", v)
+		if s == "" {
+			continue
+		}
+		*filled++
+		if earliest == "" || s < earliest {
+			earliest = s
+		}
+		if latest == "" || s > latest {
+			latest = s
+		}
+	}
+	if *filled == 0 {
+		return nil
+	}
+	return &DateStats{Earliest: earliest, Latest: latest}
+}
+
+func computeRelationStats(propName string, objects []*Object, filled *int) *RelationStats {
+	count := 0
+	for _, obj := range objects {
+		v, ok := obj.Properties[propName]
+		if !ok || v == nil {
+			continue
+		}
+		switch val := v.(type) {
+		case []any:
+			if len(val) > 0 {
+				*filled++
+				count += len(val)
+			}
+		case string:
+			if val != "" {
+				*filled++
+				count++
+			}
+		default:
+			s := fmt.Sprintf("%v", v)
+			if s != "" {
+				*filled++
+				count++
+			}
+		}
+	}
+	if count == 0 {
+		return nil
+	}
+	return &RelationStats{Count: count}
+}
+
+// toFloat64 converts various numeric representations to float64.
+func toFloat64(v any) (float64, error) {
+	switch val := v.(type) {
+	case float64:
+		return val, nil
+	case float32:
+		return float64(val), nil
+	case int:
+		return float64(val), nil
+	case int64:
+		return float64(val), nil
+	case string:
+		return strconv.ParseFloat(val, 64)
+	case json.Number:
+		return val.Float64()
+	default:
+		return strconv.ParseFloat(fmt.Sprintf("%v", v), 64)
+	}
+}
+
+// toBool converts various boolean representations to bool.
+func toBool(v any) (bool, error) {
+	switch val := v.(type) {
+	case bool:
+		return val, nil
+	case string:
+		return strconv.ParseBool(val)
+	default:
+		return strconv.ParseBool(fmt.Sprintf("%v", v))
+	}
+}

--- a/core/stats_test.go
+++ b/core/stats_test.go
@@ -1,0 +1,169 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestToFloat64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    float64
+		wantErr bool
+	}{
+		{"float64", float64(3.14), 3.14, false},
+		{"float32", float32(2.5), 2.5, false},
+		{"int", 42, 42.0, false},
+		{"int64", int64(100), 100.0, false},
+		{"string number", "3.5", 3.5, false},
+		{"string int", "7", 7.0, false},
+		{"invalid string", "abc", 0, true},
+		{"empty string", "", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toFloat64(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("toFloat64(%v) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("toFloat64(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestToBool(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    bool
+		wantErr bool
+	}{
+		{"bool true", true, true, false},
+		{"bool false", false, false, false},
+		{"string true", "true", true, false},
+		{"string false", "false", false, false},
+		{"string 1", "1", true, false},
+		{"string 0", "0", false, false},
+		{"invalid", "maybe", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toBool(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("toBool(%v) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("toBool(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeNumberStats_MixedValues(t *testing.T) {
+	objects := []*Object{
+		{Properties: map[string]any{"rating": float64(5)}},
+		{Properties: map[string]any{"rating": nil}},
+		{Properties: map[string]any{"rating": "invalid"}},
+		{Properties: map[string]any{"rating": float64(3)}},
+		{Properties: map[string]any{}},
+	}
+	var filled int
+	stats := computeNumberStats("rating", objects, &filled)
+	if filled != 2 {
+		t.Errorf("filled = %d, want 2", filled)
+	}
+	if stats == nil {
+		t.Fatal("expected non-nil stats")
+	}
+	if stats.Avg != 4.0 {
+		t.Errorf("avg = %v, want 4.0", stats.Avg)
+	}
+	if stats.Min != 3.0 {
+		t.Errorf("min = %v, want 3.0", stats.Min)
+	}
+	if stats.Max != 5.0 {
+		t.Errorf("max = %v, want 5.0", stats.Max)
+	}
+	if stats.Sum != 8.0 {
+		t.Errorf("sum = %v, want 8.0", stats.Sum)
+	}
+}
+
+func TestComputeNumberStats_AllNil(t *testing.T) {
+	objects := []*Object{
+		{Properties: map[string]any{"rating": nil}},
+		{Properties: map[string]any{}},
+	}
+	var filled int
+	stats := computeNumberStats("rating", objects, &filled)
+	if filled != 0 {
+		t.Errorf("filled = %d, want 0", filled)
+	}
+	if stats != nil {
+		t.Errorf("expected nil stats, got %v", stats)
+	}
+}
+
+func TestComputeSelectStats_EmptyValues(t *testing.T) {
+	objects := []*Object{
+		{Properties: map[string]any{"status": "active"}},
+		{Properties: map[string]any{"status": nil}},
+		{Properties: map[string]any{"status": ""}},
+		{Properties: map[string]any{}},
+	}
+	var filled int
+	stats := computeSelectStats("status", objects, &filled)
+	if filled != 1 {
+		t.Errorf("filled = %d, want 1", filled)
+	}
+	if stats == nil {
+		t.Fatal("expected non-nil stats")
+	}
+	if stats.Distribution["active"] != 1 {
+		t.Errorf("active count = %d, want 1", stats.Distribution["active"])
+	}
+}
+
+func TestComputeCheckboxStats_MixedTypes(t *testing.T) {
+	objects := []*Object{
+		{Properties: map[string]any{"done": true}},
+		{Properties: map[string]any{"done": false}},
+		{Properties: map[string]any{"done": nil}},
+		{Properties: map[string]any{}},
+	}
+	var filled int
+	stats := computeCheckboxStats("done", objects, &filled)
+	if filled != 2 {
+		t.Errorf("filled = %d, want 2", filled)
+	}
+	if stats.TrueCount != 1 {
+		t.Errorf("true = %d, want 1", stats.TrueCount)
+	}
+	if stats.FalseCount != 1 {
+		t.Errorf("false = %d, want 1", stats.FalseCount)
+	}
+}
+
+func TestComputeMultiSelectStats(t *testing.T) {
+	objects := []*Object{
+		{Properties: map[string]any{"genres": []any{"fiction", "sci-fi"}}},
+		{Properties: map[string]any{"genres": []any{"fiction"}}},
+		{Properties: map[string]any{"genres": nil}},
+		{Properties: map[string]any{}},
+	}
+	var filled int
+	stats := computeMultiSelectStats("genres", objects, &filled)
+	if filled != 2 {
+		t.Errorf("filled = %d, want 2", filled)
+	}
+	if stats.Distribution["fiction"] != 2 {
+		t.Errorf("fiction = %d, want 2", stats.Distribution["fiction"])
+	}
+	if stats.Distribution["sci-fi"] != 1 {
+		t.Errorf("sci-fi = %d, want 1", stats.Distribution["sci-fi"])
+	}
+}

--- a/marketplace/plugins/vault-guide/skills/vault-guide/SKILL.md
+++ b/marketplace/plugins/vault-guide/skills/vault-guide/SKILL.md
@@ -64,6 +64,7 @@ Object IDs support **prefix matching** — `tmd object show book/clean` works if
 | Command | Description |
 |---------|-------------|
 | `tmd doctor` | Comprehensive vault health check (superset of validate) with auto-fix |
+| `tmd stats [--type <type>] [--json]` | Vault-wide summary or per-type property aggregate statistics |
 
 ### Relations
 

--- a/websites/docs/src/content/docs/cli/stats.md
+++ b/websites/docs/src/content/docs/cli/stats.md
@@ -1,0 +1,73 @@
+---
+title: tmd stats
+description: Vault-wide summary and per-type property aggregate statistics.
+sidebar:
+  order: 11.5
+---
+
+Displays statistics about your vault. Without flags, shows a vault-wide summary. With `--type`, shows per-property aggregate statistics for a specific type.
+
+## Vault-wide summary
+
+```bash
+tmd stats
+```
+
+Shows each type's emoji, plural name, object count, last updated date, and a total across all types.
+
+### Example output
+
+```
+📚 books      12   2026-03-15
+👤 people      8   2026-03-14
+💡 ideas       5   2026-03-10
+🏷️ tags        3   2026-02-28
+
+Total: 28 objects
+```
+
+## Per-type property stats
+
+```bash
+tmd stats --type book
+```
+
+Shows aggregate statistics for each property of the specified type:
+
+| Property type | Aggregations |
+|---------------|-------------|
+| `number` | sum, avg, min, max |
+| `select` | value frequency counts |
+| `checkbox` | true/false counts |
+| `date` | earliest, latest |
+| `relation` | link count |
+
+### Example output
+
+```
+📚 books (12 objects)
+
+  rating (number)
+    sum: 46.5  avg: 3.88  min: 2  max: 5
+
+  status (select)
+    reading: 4  done: 6  to-read: 2
+
+  favorite (checkbox)
+    true: 3  false: 9
+
+  published (date)
+    earliest: 2008-08-01  latest: 2024-11-15
+
+  author (relation)
+    8 links
+```
+
+## JSON output
+
+```bash
+tmd stats --json
+tmd stats --type book --json
+```
+
+Both modes support `--json` for machine-readable output.

--- a/websites/docs/src/content/docs/zh-tw/cli/stats.md
+++ b/websites/docs/src/content/docs/zh-tw/cli/stats.md
@@ -1,0 +1,73 @@
+---
+title: tmd stats
+description: Vault 整體摘要與指定 Type 的屬性彙總統計。
+sidebar:
+  order: 11.5
+---
+
+顯示 vault 的統計資訊。不帶參數時顯示整體摘要，搭配 `--type` 時顯示指定 Type 的屬性彙總統計。
+
+## Vault 整體摘要
+
+```bash
+tmd stats
+```
+
+顯示每個 Type 的 emoji、複數名稱、Object 數量、最後更新日期，以及所有 Type 的總計。
+
+### 輸出範例
+
+```
+📚 books      12   2026-03-15
+👤 people      8   2026-03-14
+💡 ideas       5   2026-03-10
+🏷️ tags        3   2026-02-28
+
+Total: 28 objects
+```
+
+## 指定 Type 的屬性統計
+
+```bash
+tmd stats --type book
+```
+
+顯示指定 Type 每個屬性的彙總統計：
+
+| 屬性類型 | 彙總方式 |
+|---------|---------|
+| `number` | 總和、平均、最小值、最大值 |
+| `select` | 各選項出現次數 |
+| `checkbox` | true/false 計數 |
+| `date` | 最早、最晚 |
+| `relation` | 連結數量 |
+
+### 輸出範例
+
+```
+📚 books（12 個 object）
+
+  rating (number)
+    sum: 46.5  avg: 3.88  min: 2  max: 5
+
+  status (select)
+    reading: 4  done: 6  to-read: 2
+
+  favorite (checkbox)
+    true: 3  false: 9
+
+  published (date)
+    earliest: 2008-08-01  latest: 2024-11-15
+
+  author (relation)
+    8 links
+```
+
+## JSON 輸出
+
+```bash
+tmd stats --json
+tmd stats --type book --json
+```
+
+兩種模式皆支援 `--json` 以產生機器可讀的輸出。


### PR DESCRIPTION
## Summary

- Add `tmd stats` command showing vault-wide per-type summary (emoji, plural name, count, last updated)
- Add `tmd stats --type <name>` for per-property aggregation (number sum/avg/min/max, select/multi_select frequency, checkbox true/false ratio, date earliest/latest, relation link count)
- Add `--json` flag for structured JSON output in both modes
- Add `QueryService.VaultStats()` and `QueryService.TypeStats()` methods in core for reuse by MCP/Web
- Add `printJSON()` helper to `cmd/helper.go` for shared JSON marshaling

## Issue

Closes #30

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [x] Manual: `tmd stats` on a vault with multiple types
- [x] Manual: `tmd stats --type book` on a type with number/select/checkbox properties
- [x] Manual: `tmd stats --json` produces valid JSON