### PR TITLE
refactor(tui): extract shared renderPopup helper

### DIFF
--- a/tui/help.go
+++ b/tui/help.go
@@ -3,8 +3,6 @@ package tui
 import (
 	"fmt"
 	"strings"
-
-	"charm.land/lipgloss/v2"
 )
 
 const (
@@ -76,13 +74,5 @@ func renderHelp(width, height int, readOnly bool) string {
 		popupW = width - 4
 	}
 
-	popup := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(colorFocusBorder).
-		Width(popupW + 2). // +2: lipgloss v2 Width includes border
-		Padding(1, 2).
-		Render(content)
-
-	// Center the popup
-	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, popup)
+	return renderPopup(content, width, height, popupW+2) // +2: lipgloss v2 Width includes border
 }

--- a/tui/popup.go
+++ b/tui/popup.go
@@ -1,0 +1,22 @@
+package tui
+
+import "charm.land/lipgloss/v2"
+
+// renderPopup renders content as a centered popup overlay with a rounded border.
+// The border color uses the theme's colorFocusBorder. An optional width can be
+// provided to constrain the popup; pass 0 to let lipgloss auto-size from content.
+func renderPopup(content string, termW, termH int, popupWidth int) string {
+	style := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorFocusBorder).
+		Padding(1, 2)
+
+	if popupWidth > 0 {
+		style = style.Width(popupWidth)
+	}
+
+	popup := style.Render(content)
+	return lipgloss.Place(termW, termH, lipgloss.Center, lipgloss.Center, popup,
+		lipgloss.WithWhitespaceChars(" "),
+	)
+}

--- a/tui/popup_test.go
+++ b/tui/popup_test.go
@@ -1,0 +1,66 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderPopup_ContainsContent(t *testing.T) {
+	resetThemeDefaults()
+
+	out := renderPopup("hello world", 80, 24, 0)
+	if !strings.Contains(out, "hello world") {
+		t.Error("popup output should contain the content")
+	}
+}
+
+func TestRenderPopup_HasRoundedBorder(t *testing.T) {
+	resetThemeDefaults()
+
+	out := renderPopup("test", 80, 24, 0)
+	// Rounded border uses ╭ as top-left corner
+	if !strings.Contains(out, "╭") {
+		t.Error("popup should use rounded border (╭)")
+	}
+}
+
+func TestRenderPopup_IsCentered(t *testing.T) {
+	resetThemeDefaults()
+
+	out := renderPopup("X", 80, 24, 0)
+	lines := strings.Split(out, "\n")
+
+	// With 24 rows of output and a small popup, the first line should be
+	// whitespace (centering padding).
+	if len(lines) < 24 {
+		t.Fatalf("expected at least 24 lines for centering, got %d", len(lines))
+	}
+	if strings.TrimRight(lines[0], " ") != "" {
+		t.Error("first line should be blank (vertical centering)")
+	}
+}
+
+func TestRenderPopup_RespectsWidth(t *testing.T) {
+	resetThemeDefaults()
+
+	narrow := renderPopup("content", 80, 24, 20)
+	wide := renderPopup("content", 80, 24, 60)
+
+	// The wide popup should produce a wider rendered box.
+	narrowMaxW := maxLineWidth(narrow)
+	wideMaxW := maxLineWidth(wide)
+	if wideMaxW <= narrowMaxW {
+		t.Errorf("wide popup (%d) should be wider than narrow popup (%d)", wideMaxW, narrowMaxW)
+	}
+}
+
+func maxLineWidth(s string) int {
+	max := 0
+	for _, line := range strings.Split(s, "\n") {
+		w := len(strings.TrimRight(line, " "))
+		if w > max {
+			max = w
+		}
+	}
+	return max
+}

--- a/tui/type_editor.go
+++ b/tui/type_editor.go
@@ -677,11 +677,10 @@ func (te *typeEditor) renderPropPopup(termW, termH int) string {
 	pd := te.propDetail
 	p := te.schema.Properties[te.propDetailIdx]
 
-
 	var b strings.Builder
 
 	if pd.editing {
-		b.WriteString(fmt.Sprintf("  Emoji: %s", pd.emojiInput.View()))
+		b.WriteString(fmt.Sprintf("Emoji: %s", pd.emojiInput.View()))
 	} else {
 		val := p.Emoji
 		if val == "" {
@@ -689,7 +688,7 @@ func (te *typeEditor) renderPropPopup(termW, termH int) string {
 		} else {
 			val = padEmoji(val)
 		}
-		line := fmt.Sprintf("  Emoji: %s", val)
+		line := fmt.Sprintf("Emoji: %s", val)
 		if pd.cursor == 0 {
 			line = highlightStyle.Render(line)
 		}
@@ -701,9 +700,9 @@ func (te *typeEditor) renderPropPopup(termW, termH int) string {
 	// future: description field here
 
 	if pd.editing {
-		b.WriteString("\n  enter: save  esc: cancel")
+		b.WriteString("\nenter: save  esc: cancel")
 	} else {
-		b.WriteString("\n  enter: edit  esc: back")
+		b.WriteString("\nenter: edit  esc: back")
 	}
 
 	popupW := 36
@@ -713,18 +712,9 @@ func (te *typeEditor) renderPropPopup(termW, termH int) string {
 
 	titleStyle := lipgloss.NewStyle().Bold(true)
 	title := titleStyle.Render(fmt.Sprintf("%s (%s)", p.Name, p.Type))
-	fullContent := fmt.Sprintf("  %s\n  ──────────────────\n%s", title, b.String())
+	fullContent := fmt.Sprintf("%s\n──────────────────\n%s", title, b.String())
 
-	popupStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("12")).
-		Width(popupW).
-		Padding(1, 0)
-
-	popup := popupStyle.Render(fullContent)
-	return lipgloss.Place(termW, termH, lipgloss.Center, lipgloss.Center, popup,
-		lipgloss.WithWhitespaceChars(" "),
-	)
+	return renderPopup(fullContent, termW, termH, popupW)
 }
 
 // ── Add Property Wizard ─────────────────────────────────────────────────────

--- a/tui/view_picker.go
+++ b/tui/view_picker.go
@@ -3,7 +3,6 @@ package tui
 import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/huh/v2"
-	"charm.land/lipgloss/v2"
 )
 
 // viewPicker wraps a huh.Form with a single Select field for choosing a view.
@@ -80,13 +79,5 @@ func (vp *viewPicker) Update(msg tea.Msg) (*viewPicker, tea.Cmd) {
 func (vp *viewPicker) View(width, height int) string {
 	content := vp.form.View()
 
-	popupStyle := lipgloss.NewStyle().
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("12")).
-		Padding(1, 2)
-
-	popup := popupStyle.Render(content)
-	return lipgloss.Place(width, height, lipgloss.Center, lipgloss.Center, popup,
-		lipgloss.WithWhitespaceChars(" "),
-	)
+	return renderPopup(content, width, height, 0)
 }


### PR DESCRIPTION
## Summary

- Extract shared `renderPopup()` helper from 3 duplicate popup overlay implementations (`help.go`, `type_editor.go`, `view_picker.go`)
- Unify border color to use theme's `colorFocusBorder` instead of hardcoded `Color("12")`
- Remove manual padding prefixes from type editor content (now handled by style `Padding(1, 2)`)

## Issue

Closes #261

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [x] Manual: open TUI, verify help popup (`?`), property detail popup (Enter on property), and view picker popup (`v`) render correctly with consistent border color

🤖 Generated with [Claude Code](https://claude.com/claude-code)