### PR TITLE
feat(tui): apply ViewConfig filter rules in view mode

### DIFF
--- a/tui/view_mode.go
+++ b/tui/view_mode.go
@@ -70,8 +70,9 @@ func (vm *viewMode) load() {
 
 	vm.schema, _ = vm.vault.LoadType(vm.typeName)
 
-	// Query objects using vault facade
-	objects, err := vm.vault.QueryObjects(core.TypeFilter(vm.typeName), vm.view.Sort...)
+	// Query objects using vault facade, combining type filter with view filter rules
+	filter := append(core.TypeFilter(vm.typeName), vm.view.Filter...)
+	objects, err := vm.vault.QueryObjects(filter, vm.view.Sort...)
 	if err != nil {
 		vm.objects = nil
 	} else {


### PR DESCRIPTION
## Summary

- View mode now applies `ViewConfig.Filter` rules when querying objects, combining them with the implicit `TypeFilter` so only matching objects are displayed

## Issue

Closes #264

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no issues
- [x] Manual: create a view with filter rules (e.g., `status is reading`), verify only matching objects appear in view mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)