### PR TITLE
docs: fix consistency issues across docs, OpenSpec, and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,7 @@ Type creation uses a **title panel wizard** (`createTypeState` in `tui/create_ty
 - Built-in types: `tag` (🏷️, plural "tags", unique, backs `tags` system property) and `page` (📄, plural "pages", general-purpose content container). Built-in types exist without YAML files, cannot be deleted, but can be overridden by custom `.typemd/types/<name>.yaml`.
 - Shared properties: `.typemd/properties.yaml` (optional, defines reusable property definitions referenced via `use` in type schemas; `use` entries can override `pin`, `emoji`, and `description`)
 - Relations defined as properties in type schemas
-- Wiki-links: `[[type/name-ulid]]` syntax in markdown body, with backlink tracking
+- Wiki-links: `[[type/slug-ulid]]` syntax in markdown body, with backlink tracking
 - SQLite index: `.typemd/index.db`
 - TUI session state: `.typemd/tui-state.yaml` (persisted on quit, restored on launch; stores `selected_object_id` or `selected_type_name`, expanded groups, scroll offset, panel widths, props visibility, and optionally view mode state — `view_type_name`, `view_name`, `view_cursor`, `view_scroll`, `view_expanded_groups` — when the TUI was in view mode on exit)
 - Vault config: `.typemd/config.yaml` (interface-layer namespacing; `cli.default_type` sets the default type for `tmd object create`; `tmd init` always creates this with `default_type: page`)

--- a/openspec/specs/shared-properties/spec.md
+++ b/openspec/specs/shared-properties/spec.md
@@ -19,7 +19,7 @@ The system SHALL support an optional `.typemd/properties.yaml` file that defines
 
 ### Requirement: Shared properties support all property fields
 
-Shared property definitions SHALL support all fields available in type schema properties: `name`, `type`, `emoji`, `pin`, `options`, `target`, `default`, `multiple`, `bidirectional`, `inverse`.
+Shared property definitions SHALL support all fields available in type schema properties: `name`, `type`, `emoji`, `description`, `pin`, `options`, `target`, `default`, `multiple`, `bidirectional`, `inverse`.
 
 #### Scenario: Shared property with options
 

--- a/openspec/specs/type-schema/spec.md
+++ b/openspec/specs/type-schema/spec.md
@@ -244,7 +244,7 @@ A type schema SHALL NOT define a `name` property that has the same name as any s
 
 ### Requirement: LoadType resolves use entries
 
-`LoadType()` SHALL resolve all `use` entries in a type schema by replacing them with fully resolved Property objects. The resolved Property SHALL have all fields from the shared definition, with `pin` and `emoji` overridden if specified in the `use` entry. After resolution, the `Use` field SHALL be empty.
+`LoadType()` SHALL resolve all `use` entries in a type schema by replacing them with fully resolved Property objects. The resolved Property SHALL have all fields from the shared definition, with `pin`, `emoji`, and `description` overridden if specified in the `use` entry. After resolution, the `Use` field SHALL be empty.
 
 #### Scenario: Use entry resolved with no overrides
 

--- a/openspec/specs/unique-constraint/spec.md
+++ b/openspec/specs/unique-constraint/spec.md
@@ -1,6 +1,6 @@
 ## Purpose
 
-Name uniqueness constraint on type schemas. Types with `unique: true` enforce that no two objects share the same `name` value.
+Name uniqueness constraint on type schemas. Types with `unique: true` enforce that no two objects **of the same type** share the same `name` value.
 
 ## Requirements
 

--- a/openspec/specs/wiki-links/spec.md
+++ b/openspec/specs/wiki-links/spec.md
@@ -96,7 +96,7 @@ The `tmd type validate` command SHALL report links whose targets do not resolve 
 #### Scenario: Broken link is reported
 
 - **WHEN** an object contains a link `[[person/nobody-01jjjjjjjjjjjjjjjjjjjjjjjj]]` that does not resolve
-- **THEN** validation reports `<object-id>: broken link [[person/nobody-01jjjjjjjjjjjjjjjjjjjjjjjj]]`
+- **THEN** validation reports `<object-id>: broken wiki-link [[person/nobody-01jjjjjjjjjjjjjjjjjjjjjjjj]]`
 
 #### Scenario: Valid links pass validation
 

--- a/websites/docs/src/content/docs/advanced/file-structure.md
+++ b/websites/docs/src/content/docs/advanced/file-structure.md
@@ -120,7 +120,8 @@ filter:
   - property: status
     operator: is
     value: reading
-group_by: genre
+group_by:
+  - property: genre
 ```
 
 Two layouts are available:

--- a/websites/docs/src/content/docs/basics/properties.md
+++ b/websites/docs/src/content/docs/basics/properties.md
@@ -13,7 +13,7 @@ Every Object supports five system properties managed by TypeMD. These provide th
 
 | Property | Description | Mutability | Why |
 |----------|-------------|------------|-----|
-| `name` | Display name, auto-populated from the slug on creation | User-authored | Decouples display from filename — supports spaces, casing, and renaming without moving files |
+| `name` | Display name, auto-populated from the slug on creation (or auto-generated from a [name template](/basics/templates#name-templates) when defined) | User-authored | Decouples display from filename — supports spaces, casing, and renaming without moving files |
 | `description` | Optional single-line summary for list displays and search results | User-authored | Provides a consistent summary field across all types, used in list views, search results, and API responses |
 | `created_at` | Creation timestamp in RFC 3339 format (set once, never modified) | Auto-managed | Enables sorting by creation date and understanding the timeline of a vault |
 | `updated_at` | Last-modified timestamp in RFC 3339 format (updated on every save) | Auto-managed | Enables sorting by recency and tracking the evolution of Objects |
@@ -181,7 +181,7 @@ properties:
 |---|----------------|-----------------|
 | Defined in | `.typemd/properties.yaml` | `.typemd/types/<type>.yaml` |
 | Reusable | Yes — referenced via `use` | No — scoped to one type |
-| Customizable per type | `pin` and `emoji` only | Fully customizable |
+| Customizable per type | `pin`, `emoji`, and `description` only | Fully customizable |
 | Use case | Properties shared across multiple types | Properties unique to one type |
 
 **Rule of thumb**: if a property appears in two or more types with the same definition, make it a shared property.

--- a/websites/docs/src/content/docs/basics/validation.md
+++ b/websites/docs/src/content/docs/basics/validation.md
@@ -48,7 +48,7 @@ Detects broken links — `[[target]]` references in object body content where th
 
 ### Phase 5: Name Uniqueness Validation
 
-Checks all types with `unique: true` in their schema (e.g., the built-in `tag` type) to ensure no two objects of the same type share the same `name` value.
+Checks all types with `unique: true` in their schema (e.g., the built-in `tag` type) to ensure no two objects of the same type share the same `name` value. The uniqueness comparison uses exact string match — it is case-sensitive and no normalization (case folding, whitespace trimming) is applied.
 
 ## Lenient validation philosophy
 

--- a/websites/docs/src/content/docs/concepts/glossary.md
+++ b/websites/docs/src/content/docs/concepts/glossary.md
@@ -65,6 +65,28 @@ A saved configuration that controls how Objects of a Type are displayed — incl
 
 [Learn more →](/advanced/file-structure#views)
 
+## System Property
+
+A property managed by TypeMD that exists on every Object: `name`, `description`, `created_at`, `updated_at`, and `tags`. System properties appear first in frontmatter in a fixed order. User-authored system properties (`name`, `description`, `tags`) can be overridden by templates; auto-managed ones (`created_at`, `updated_at`) cannot.
+
+[Learn more →](/basics/properties#system-properties)
+
+## Shared Property
+
+A reusable property definition in `.typemd/properties.yaml` that can be referenced from type schemas via the `use` keyword. Shared properties ensure consistent definitions across types. When referencing, you can override `pin`, `emoji`, and `description` per type.
+
+[Learn more →](/basics/properties#shared-properties)
+
+## Query
+
+A structured filter-and-sort request against the index. Queries use filter rules (property + operator + value) and sort rules (property + direction) to retrieve matching Objects of a given Type. Exposed via the CLI (`tmd query`) and used internally by Views.
+
+[Learn more →](/basics/queries)
+
+## Search
+
+A full-text search across Object names, descriptions, and body content. Unlike Queries which filter on structured properties, Search matches free-text input against the search index. Exposed via the CLI (`tmd search`) and the TUI search bar.
+
 ## Slug
 
 The human-readable part of an Object's filename. For example, `golang-in-action` in `book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz.md`. Derived from the name you provide when creating an Object.

--- a/websites/docs/src/content/docs/concepts/objects.md
+++ b/websites/docs/src/content/docs/concepts/objects.md
@@ -17,8 +17,10 @@ An Object is a Markdown file with two parts:
 ```markdown
 ---
 name: golang-in-action
+description:
 created_at: "2026-03-09T10:30:00+08:00"
 updated_at: "2026-03-11T18:00:00+08:00"
+tags: []
 title: Go in Action
 status: reading
 rating: 4.5

--- a/websites/docs/src/content/docs/concepts/relations.md
+++ b/websites/docs/src/content/docs/concepts/relations.md
@@ -72,6 +72,11 @@ tmd relation unlink book/golang-in-action author person/alan-donovan --both
 
 Use `--both` to remove the inverse side as well. This only takes effect when the relation property has `bidirectional: true` and an `inverse` field defined in the schema.
 
+## Behavior details
+
+- **Duplicate links are rejected** — For multiple-value relations, linking the same target object twice is rejected. Each target can appear at most once in the list.
+- **Reverse relations** — In the TUI object detail view, reverse relations (where the current object is the target of another object's relation) appear with a `←` indicator to distinguish them from forward relations.
+
 ## Relations vs. wiki-links
 
 TypeMD also supports [links](/concepts/links) (`[[type/slug]]`) for informal inline references. Relations are structured and schema-defined; links are freeform and live in the Markdown body. See the [Links](/concepts/links) page for a detailed comparison.

--- a/websites/docs/src/content/docs/concepts/types.md
+++ b/websites/docs/src/content/docs/concepts/types.md
@@ -11,10 +11,10 @@ A Type is a blueprint that defines what kind of Object you're working with and w
 
 Think of a Type as a category with structure. A `book` Type knows that books have a title, a reading status, and a rating. A `person` Type knows that people have a name and a role.
 
-Types are defined as YAML schema files in `.typemd/types/`:
+Types are defined as YAML schema files in `.typemd/types/<name>/schema.yaml`:
 
 ```yaml
-# .typemd/types/book.yaml
+# .typemd/types/book/schema.yaml
 name: book
 plural: books
 emoji: 📚
@@ -59,7 +59,13 @@ TypeMD has two built-in Types:
 | 🏷️ `tag` | color (string), icon (string) | Backs the `tags` system property; has `unique: true` to enforce name uniqueness |
 | 📄 `page` | _(none)_ | General-purpose content container for free-form writing |
 
-Built-in types exist in every vault automatically and cannot be deleted. You can override them by creating a custom `.typemd/types/<name>.yaml` file with additional properties. All other types are user-defined via `.typemd/types/*.yaml` files. TypeMD deliberately avoids shipping opinionated types like `book` or `note` — you design the types that fit your domain.
+Built-in types exist in every vault automatically and cannot be deleted. You can override them by creating a custom `.typemd/types/<name>/schema.yaml` file with additional properties. All other types are user-defined via `.typemd/types/*/schema.yaml` files.
+
+:::note
+Legacy single-file format (`.typemd/types/book.yaml`) is automatically migrated to directory format (`book/schema.yaml`) on first load.
+:::
+
+TypeMD deliberately avoids shipping opinionated types like `book` or `note` — you design the types that fit your domain.
 
 For details on tags, see [Tags](/basics/tags).
 
@@ -80,6 +86,8 @@ Each property in a Type schema has a data type:
 | `select` | One of a fixed set of options | `"reading"` |
 | `multi_select` | Multiple values from options | `["go", "programming"]` |
 | `relation` | A link to another Object | `"person/alan-donovan"` |
+
+`select` and `multi_select` properties require an `options` array. Each option has a `value` (required) and an optional `label` for display. When `label` is omitted, it defaults to the `value`. See [Properties](/basics/properties#choice-types) for a full example.
 
 For relation properties, see the [Relations](/concepts/relations) page for details on `target`, `bidirectional`, `inverse`, and `multiple` fields.
 

--- a/websites/docs/src/content/docs/zh-tw/advanced/file-structure.md
+++ b/websites/docs/src/content/docs/zh-tw/advanced/file-structure.md
@@ -86,6 +86,8 @@ book/golang-in-action-01jqr3k5mpbvn8e0f2g7h9txyz
 # .typemd/types/book/schema.yaml
 name: book
 plural: books
+color: blue
+description: "Books I've read or want to read"
 unique: false
 properties:
   - name: status
@@ -104,7 +106,7 @@ properties:
 
 完整的 type schema 格式請參閱 [Type](/zh-tw/concepts/types)。
 
-## View
+## Views
 
 每個 type 可以有多個已儲存的 view，定義物件的排序、篩選和顯示方式。View 以 YAML 檔案儲存在 `.typemd/types/<name>/views/`：
 
@@ -120,7 +122,8 @@ filter:
   - property: status
     operator: is
     value: reading
-group_by: genre
+group_by:
+  - property: genre
 ```
 
 有兩種佈局可用：

--- a/websites/docs/src/content/docs/zh-tw/basics/properties.md
+++ b/websites/docs/src/content/docs/zh-tw/basics/properties.md
@@ -85,6 +85,7 @@ Type schema 中的每個屬性都有一個 `type`，決定它接受什麼值以�
 | 設定 | 型別 | 說明 |
 |------|------|------|
 | `emoji` | string | 簡潔顯示用的視覺圖示（在同一 type 內必須唯一） |
+| `description` | string | 自由文字，說明該屬性的用途 |
 | `pin` | integer | 正整數，讓屬性突出顯示在 TUI body 面板頂端。數值越小排越前面。已置頂的屬性不會出現在 Properties 面板中。 |
 | `default` | any | 建立新 object 時指定的預設值 |
 
@@ -154,12 +155,13 @@ properties:
 
 ### 覆寫欄位
 
-透過 `use` 引用共用屬性時，你可以覆寫兩個欄位：
+透過 `use` 引用共用屬性時，你可以覆寫三個欄位：
 
 | 欄位 | 說明 |
 |------|------|
 | `pin` | 覆寫此 type 中的置頂位置 |
 | `emoji` | 覆寫此 type 中的顯示 emoji |
+| `description` | 覆寫此 type 中的屬性說明 |
 
 其他所有欄位不能覆寫——它們來自共用定義。
 
@@ -179,7 +181,7 @@ properties:
 |---|---------|---------|
 | 定義位置 | `.typemd/properties.yaml` | `.typemd/types/<type>.yaml` |
 | 可重複使用 | 是——透過 `use` 引用 | 否——僅限單一 type |
-| 可依 type 自訂 | 僅限 `pin` 和 `emoji` | 完全可自訂 |
+| 可依 type 自訂 | 僅限 `pin`、`emoji` 和 `description` | 完全可自訂 |
 | 適用情境 | 多個 type 共用的屬性 | 單一 type 獨有的屬性 |
 
 **經驗法則**：如果某個屬性以相同的定義出現在兩個以上的 type 中，就把它做成共用屬性。

--- a/websites/docs/src/content/docs/zh-tw/concepts/glossary.md
+++ b/websites/docs/src/content/docs/zh-tw/concepts/glossary.md
@@ -63,7 +63,29 @@ TypeMD 中知識的基本單位。你不需要用「檔案」或「筆記」來�
 
 已儲存的設定，控制某個 Type 的物件如何顯示 — 包含排序順序、篩選規則、分組和佈局。View 以 YAML 檔案儲存在 `.typemd/types/<name>/views/`。每個 Type 都有一個隱含的預設 View（list 佈局，按 name 排序）。
 
-[深入了解 →](/zh-tw/advanced/file-structure#view)
+[深入了解 →](/zh-tw/advanced/file-structure#views)
+
+## System Property（系統屬性）
+
+由 TypeMD 管理、存在於每個 Object 上的屬性：`name`、`description`、`created_at`、`updated_at` 和 `tags`。系統屬性在 frontmatter 中依固定順序排在最前面。使用者撰寫的系統屬性（`name`、`description`、`tags`）可以被 template 覆蓋；自動管理的（`created_at`、`updated_at`）不能覆蓋。
+
+[深入了解 →](/zh-tw/basics/properties#系統屬性)
+
+## Shared Property（共用屬性）
+
+定義在 `.typemd/properties.yaml` 中的可重複使用屬性定義，type schema 可透過 `use` 關鍵字引用。共用屬性確保跨 type 的定義一致。引用時可以依 type 覆寫 `pin`、`emoji` 和 `description`。
+
+[深入了解 →](/zh-tw/basics/properties#共用屬性)
+
+## Query（查詢）
+
+對索引進行的結構化篩選與排序請求。查詢使用篩選規則（屬性 + 運算子 + 值）和排序規則（屬性 + 方向）來擷取指定 Type 的符合物件。透過 CLI（`tmd query`）公開，View 也在內部使用。
+
+[深入了解 →](/zh-tw/basics/queries)
+
+## Search（搜尋）
+
+跨物件名稱、描述和內文的全文搜尋。不同於查詢（Query）是針對結構化屬性篩選，搜尋會將自由文字輸入與搜尋索引比對。透過 CLI（`tmd search`）和 TUI 搜尋列公開。
 
 ## Slug
 

--- a/websites/docs/src/content/docs/zh-tw/concepts/objects.md
+++ b/websites/docs/src/content/docs/zh-tw/concepts/objects.md
@@ -17,8 +17,10 @@ Object 是一個 Markdown 檔案，由兩個部分組成：
 ```markdown
 ---
 name: golang-in-action
+description:
 created_at: "2026-03-09T10:30:00+08:00"
 updated_at: "2026-03-11T18:00:00+08:00"
+tags: []
 title: Go in Action
 status: reading
 rating: 4.5

--- a/websites/docs/src/content/docs/zh-tw/concepts/relations.md
+++ b/websites/docs/src/content/docs/zh-tw/concepts/relations.md
@@ -1,5 +1,5 @@
 ---
-title: Relation
+title: Relations
 description: Object 之間如何透過帶型別的連結互相連接。
 sidebar:
   order: 4
@@ -71,6 +71,11 @@ tmd relation unlink book/golang-in-action author person/alan-donovan --both
 ```
 
 使用 `--both` 來同時移除反向端。這只在 schema 中定義了 `bidirectional: true` 和 `inverse` 欄位時才有效。
+
+## 行為細節
+
+- **重複連結會被拒絕** — 對於多值 relation，連結同一個目標物件兩次會被拒絕。每個目標在清單中最多只能出現一次。
+- **反向 relation** — 在 TUI 的 object 詳細檢視中，反向 relation（目前 object 是另一個 object 的 relation 目標）會以 `←` 指示符標示，與正向 relation 區分。
 
 ## Relation vs. Wiki-link
 

--- a/websites/docs/src/content/docs/zh-tw/concepts/types.md
+++ b/websites/docs/src/content/docs/zh-tw/concepts/types.md
@@ -11,10 +11,10 @@ Type（類型）是定義 Object 種類和屬性的藍圖。
 
 把 Type 想成一個帶有結構的分類。`book` Type 知道書有標題、閱讀狀態和評分。`person` Type 知道人有名字和角色。
 
-Type 以 YAML schema 檔案定義，放在 `.typemd/types/`：
+Type 以 YAML schema 檔案定義，放在 `.typemd/types/<name>/schema.yaml`：
 
 ```yaml
-# .typemd/types/book.yaml
+# .typemd/types/book/schema.yaml
 name: book
 plural: books
 emoji: 📚
@@ -36,6 +36,12 @@ properties:
 
 可選的 `emoji` 欄位為 Type 提供視覺圖示，顯示在 CLI 和 TUI 的輸出中。
 
+可選的 `color` 欄位為 Type 指定視覺主題色彩，用於 TUI 和 Web UI。接受預設色彩名稱（`red`、`blue`、`green`、`yellow`、`purple`、`orange`、`pink`、`cyan`、`gray`、`brown`）或自訂十六進位色碼（`#RGB` 或 `#RRGGBB`）。
+
+可選的 `description` 欄位提供 Type 用途的自由文字說明（例如 `description: "Books I've read or want to read"`）。這與 object 上的 `description` 系統屬性不同。
+
+可選的 `version` 欄位是 semver 風格的 `"major.minor"` 字串，用於追蹤 schema 演進（例如 `version: "1.0"`）。未設定時預設為 `"0.0"`（未版本化）。主版號用於不相容變更，次版號用於向後相容變更，為未來的遷移工具提供基礎。
+
 ## 為什麼需要 Type
 
 Type 為你的知識庫帶來**一致性**和**可查詢性**：
@@ -53,7 +59,13 @@ TypeMD 有兩個內建 Type：
 | 🏷️ `tag` | color (string)、icon (string) | 支援 `tags` 系統屬性；具有 `unique: true` 以強制 name 唯一性 |
 | 📄 `page` | _（無）_ | 通用內容容器，用於自由形式的寫作 |
 
-內建 type 存在於每個 vault 中，無法刪除。你可以透過建立自訂的 `.typemd/types/<name>.yaml` 檔案來覆蓋它們並新增屬性。所有其他 type 都由使用者透過 `.typemd/types/*.yaml` 檔案自行定義。TypeMD 刻意不預設附帶 `book` 或 `note` 等帶有主觀用途的 type——你可以設計符合自己領域的 type。
+內建 type 存在於每個 vault 中，無法刪除。你可以透過建立自訂的 `.typemd/types/<name>/schema.yaml` 檔案來覆蓋它們並新增屬性。所有其他 type 都由使用者透過 `.typemd/types/*/schema.yaml` 檔案自行定義。
+
+:::note
+舊版單檔格式（`.typemd/types/book.yaml`）會在首次載入時自動遷移為目錄格式（`book/schema.yaml`）。
+:::
+
+TypeMD 刻意不預設附帶 `book` 或 `note` 等帶有主觀用途的 type——你可以設計符合自己領域的 type。
 
 關於標籤的詳細說明，請參閱[標籤](/zh-tw/basics/tags)。
 
@@ -75,7 +87,9 @@ Type schema 中每個屬性都有一個資料型別：
 | `multi_select` | 固定選項中的多個值 | `["go", "programming"]` |
 | `relation` | 連結到另一個 Object | `"person/alan-donovan"` |
 
-Relation 屬性的 `target`、`bidirectional`、`inverse` 和 `multiple` 欄位，請參閱 [Relation](/zh-tw/concepts/relations) 頁面。
+`select` 和 `multi_select` 屬性需要 `options` 陣列。每個選項有 `value`（必填）和可選的 `label` 顯示名稱。省略 `label` 時預設等於 `value`。完整範例請參閱[屬性](/zh-tw/basics/properties#選擇型別)。
+
+Relation 屬性的 `target`、`bidirectional`、`inverse` 和 `multiple` 欄位，請參閱 [Relations](/zh-tw/concepts/relations) 頁面。
 
 如果某個屬性出現在多個 type 中，你可以定義一次然後重複使用。詳情請參閱 [Shared Properties](/zh-tw/basics/properties#shared-properties)。
 
@@ -92,3 +106,11 @@ TypeMD 採用寬鬆驗證：
 - `url` 必須以 http:// 或 https:// 開頭
 - `relation` 的目標會檢查 Type 是否正確
 - 屬性名稱 `description`、`created_at`、`updated_at` 和 `tags` 為[系統屬性](/zh-tw/advanced/file-structure#系統屬性)保留，不能在 type schema 中使用。`name` 可以出現在 `properties` 中，但只允許搭配 `template` 欄位（用於 [name template](/zh-tw/basics/templates#name-template)）。
+
+## Views
+
+每個 type 可以有一個或多個 **view** — 已儲存的設定，控制物件的顯示方式（排序、篩選、分組）。View 儲存在 type schema 旁的 `.typemd/types/<name>/views/` 中。
+
+每個 type 都有一個隱含的預設 view（list 佈局，按 name 排序）。你可以建立自訂 view，設定不同的排序順序、篩選條件和分組方式。在 TUI 中，對 type 群組按 `v` 即可進入 [view 模式](/zh-tw/tui/tui#view-mode--table-display)。
+
+View 設定格式的詳細說明，請參閱[檔案結構：Views](/zh-tw/advanced/file-structure#views)。篩選運算子請參閱[查詢：篩選運算子](/zh-tw/basics/queries#filter-operators)。


### PR DESCRIPTION
## Summary

- Address 22 TEXT-category findings from a full consistency check across BDD feature files, OpenSpec specs, and documentation (EN + ZH-TW)
- Fix terminology inconsistencies, missing documentation, stale translations, and OpenSpec inaccuracies
- No behavioral changes — all edits are documentation and spec text only

### Highlights

| Area | Fix |
|------|-----|
| CLAUDE.md | `[[type/name-ulid]]` → `[[type/slug-ulid]]` |
| Glossary (EN + ZH-TW) | Add missing entries: System Property, Shared Property, Query, Search |
| ZH-TW types.md | Add `color`, `description`, `version` field docs |
| properties.md (EN + ZH-TW) | Fix comparison table to include `description` as overridable field |
| types.md (EN + ZH-TW) | Update path to directory format, add `label` sub-field docs, add Views section (ZH-TW) |
| objects.md (EN + ZH-TW) | Add `description:` and `tags: []` to frontmatter example |
| relations.md (EN + ZH-TW) | Add duplicate link rejection + reverse `←` indicator docs; fix ZH-TW title |
| file-structure.md (EN + ZH-TW) | Fix `group_by` to canonical array format; add `color`/`description` to ZH-TW example |
| validation.md | Add exact string match note for unique constraint |
| OpenSpec shared-properties | Add `description` to supported fields and override list |
| OpenSpec wiki-links | Fix validation message: "broken link" → "broken wiki-link" |
| OpenSpec unique-constraint | Add "of the same type" to Purpose section |

## Test plan

- [ ] Verify docs site builds without errors (`npm run build` in `websites/docs/`)
- [ ] Spot-check EN and ZH-TW pages render correctly
- [ ] Confirm no broken internal links in glossary entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)