### PR TITLE
fix(core): resolve wiki-links from files instead of DB

### DIFF
--- a/core/bdd_steps_validate_test.go
+++ b/core/bdd_steps_validate_test.go
@@ -73,6 +73,14 @@ func (dc *domainContext) twoLinkedNotesExist() {
 }
 
 func (dc *domainContext) aNoteWithABrokenWikiLinkExists() {
+	dc.createNoteWithBrokenWikiLink(true)
+}
+
+func (dc *domainContext) aNoteWithABrokenWikiLinkExistsOnAFreshVault() {
+	dc.createNoteWithBrokenWikiLink(false)
+}
+
+func (dc *domainContext) createNoteWithBrokenWikiLink(sync bool) {
 	os.WriteFile(filepath.Join(dc.vault.TypesDir(), "note.yaml"),
 		[]byte("name: note\nproperties:\n  - name: title\n    type: string\n"), 0644)
 
@@ -81,7 +89,9 @@ func (dc *domainContext) aNoteWithABrokenWikiLinkExists() {
 
 	body := "---\ntitle: Alpha\n---\n\nSee [[note/nonexistent-01jjjjjjjjjjjjjjjjjjjjjjjj]].\n"
 	os.WriteFile(dc.vault.ObjectPath(note.Type, note.Filename), []byte(body), 0644)
-	dc.vault.SyncIndex()
+	if sync {
+		dc.vault.SyncIndex()
+	}
 }
 
 func (dc *domainContext) iValidateWikiLinks() {
@@ -140,6 +150,7 @@ func initValidateSteps(ctx *godog.ScenarioContext, dc *domainContext) {
 	ctx.Step(`^there should be (\d+) relation errors?$`, dc.thereShouldBeNRelationErrors)
 	ctx.Step(`^two linked notes exist$`, dc.twoLinkedNotesExist)
 	ctx.Step(`^a note with a broken wiki-link exists$`, dc.aNoteWithABrokenWikiLinkExists)
+	ctx.Step(`^a note with a broken wiki-link exists on a fresh vault$`, dc.aNoteWithABrokenWikiLinkExistsOnAFreshVault)
 	ctx.Step(`^I validate wiki-links$`, dc.iValidateWikiLinks)
 	ctx.Step(`^there should be no wiki-link errors$`, dc.thereShouldBeNoWikiLinkErrors)
 	ctx.Step(`^there should be (\d+) wiki-link errors?$`, dc.thereShouldBeNWikiLinkErrors)

--- a/core/features/validate.feature
+++ b/core/features/validate.feature
@@ -44,3 +44,10 @@ Feature: Validation
     When I validate wiki-links
     Then there should be 1 wiki-link error
     And the error should mention "broken wiki-link"
+
+  Scenario: Broken wiki-link is detected on a fresh vault
+    Given a vault is ready
+    And a note with a broken wiki-link exists on a fresh vault
+    When I validate wiki-links
+    Then there should be 1 wiki-link error
+    And the error should mention "broken wiki-link"

--- a/core/validate.go
+++ b/core/validate.go
@@ -122,24 +122,27 @@ func checkRelationRef(ref, objectID, propName string, errs *[]error) {
 }
 
 // ValidateWikiLinks checks for broken wiki-links (targets that don't resolve to existing objects).
+// It walks object files directly rather than relying on the SQLite index,
+// so validation works correctly even without a prior sync.
 func ValidateWikiLinks(v *Vault) []error {
 	var errs []error
-	rows, err := v.db.Query("SELECT from_id, target FROM wikilinks WHERE to_id = ''")
+	objects, err := v.repo.Walk()
 	if err != nil {
-		return []error{fmt.Errorf("query broken wikilinks: %w", err)}
+		return []error{fmt.Errorf("walk objects: %w", err)}
 	}
-	defer rows.Close()
 
-	for rows.Next() {
-		var fromID, target string
-		if err := rows.Scan(&fromID, &target); err != nil {
-			errs = append(errs, fmt.Errorf("scan wikilink: %w", err))
-			continue
-		}
-		errs = append(errs, fmt.Errorf("%s: broken wiki-link [[%s]]", fromID, target))
+	knownIDs := make(map[string]bool, len(objects))
+	for _, obj := range objects {
+		knownIDs[obj.ID] = true
 	}
-	if err := rows.Err(); err != nil {
-		errs = append(errs, fmt.Errorf("iterate wikilinks: %w", err))
+
+	for _, obj := range objects {
+		links := ParseWikiLinks(obj.Body)
+		for _, link := range links {
+			if !knownIDs[link.Target] {
+				errs = append(errs, fmt.Errorf("%s: broken wiki-link [[%s]]", obj.ID, link.Target))
+			}
+		}
 	}
 	return errs
 }


### PR DESCRIPTION
## Summary

- `ValidateWikiLinks` now walks object files directly (`repo.Walk()`) instead of querying the SQLite `wikilinks` table
- Validation works correctly on fresh vaults without prior sync, fixing false-green results in CI
- Follows the same file-based pattern as `ValidateRelationReferences`

## Issue

Closes #306

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [ ] Manual: create a vault with a broken wiki-link, run `tmd validate` without `--reindex` and verify the broken link is reported