### PR TITLE
refactor(tui): extract shared text utilities into textutil.go

### DIFF
--- a/tui/app_render.go
+++ b/tui/app_render.go
@@ -23,30 +23,6 @@ func (m model) selectedTypeEmoji() string {
 	return ""
 }
 
-// softWrapLines wraps each line individually, preserving leading indentation on continuation lines.
-func softWrapLines(content string, width int) string {
-	lines := strings.Split(content, "\n")
-	var result []string
-	for _, line := range lines {
-		if lipgloss.Width(line) <= width {
-			result = append(result, line)
-			continue
-		}
-		// Detect leading whitespace
-		trimmed := strings.TrimLeft(line, " ")
-		indent := line[:len(line)-len(trimmed)]
-		wrapped := lipgloss.NewStyle().Width(width - lipgloss.Width(indent)).Render(trimmed)
-		for i, wl := range strings.Split(wrapped, "\n") {
-			if i == 0 {
-				result = append(result, indent+wl)
-			} else {
-				result = append(result, indent+wl)
-			}
-		}
-	}
-	return strings.Join(result, "\n")
-}
-
 // updateDetail refreshes viewport contents with current selected object.
 func (m *model) updateDetail() {
 	bodyContent := renderBody(m.selected, m.bodyViewport.Width(), m.displayProps)
@@ -384,7 +360,7 @@ func (m model) View() tea.View {
 				name := row.Object.GetName()
 				maxWidth := leftW - 3 - runewidth.StringWidth(row.Object.Type) - 1 // 3 = leading spaces, 1 = "/"
 				if maxWidth > 0 {
-					name = runewidth.Truncate(name, maxWidth, "…")
+					name = truncate(name, maxWidth)
 				}
 				line := fmt.Sprintf("   %s/%s", row.Object.Type, name)
 				if i == m.cursor {

--- a/tui/detail.go
+++ b/tui/detail.go
@@ -31,14 +31,14 @@ func renderTitleContent(obj *core.Object, typeName, emoji string, width int) str
 	title := titlePrefix(emoji, typeName) + " · " + obj.GetName()
 	if !obj.IsLocked() {
 		if width > 0 {
-			title = runewidth.Truncate(title, width, "…")
+			title = truncate(title, width)
 		}
 		return title
 	}
 	badge := " 🔒"
 	badgeW := runewidth.StringWidth(badge)
 	if width > 0 {
-		title = runewidth.Truncate(title, width-badgeW, "…")
+		title = truncate(title, width-badgeW)
 		pad := width - runewidth.StringWidth(title) - badgeW
 		if pad > 0 {
 			title += strings.Repeat(" ", pad)

--- a/tui/list.go
+++ b/tui/list.go
@@ -5,20 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/mattn/go-runewidth"
 	"github.com/typemd/typemd/core"
 )
-
-// padEmoji strips the variation selector (U+FE0F) and pads the emoji
-// to a consistent 2-cell display width for terminal alignment.
-func padEmoji(emoji string) string {
-	display := strings.ReplaceAll(emoji, "\uFE0F", "")
-	ew := runewidth.StringWidth(display)
-	if ew < 2 {
-		return display + strings.Repeat(" ", 2-ew)
-	}
-	return display
-}
 
 type rowKind int
 
@@ -144,7 +132,7 @@ func renderList(groups []typeGroup, cursor, scrollOffset int, focused bool, widt
 			name := row.Object.GetName()
 			maxNameWidth := width - 3 // 3 = leading spaces "   "
 			if maxNameWidth > 0 {
-				name = runewidth.Truncate(name, maxNameWidth, "…")
+				name = truncate(name, maxNameWidth)
 			}
 			line = fmt.Sprintf("   %s", name)
 		case rowNewType:

--- a/tui/stats_mode.go
+++ b/tui/stats_mode.go
@@ -372,7 +372,7 @@ func (sm *statsMode) renderDistribution(dist map[string]int, barMaxW int) []stri
 		bar := renderBar(e.count, maxCount, barMaxW)
 		name := e.name
 		if runewidth.StringWidth(name) > maxLabelW {
-			name = runewidth.Truncate(name, maxLabelW, "…")
+			name = truncate(name, maxLabelW)
 		}
 		lines = append(lines, fmt.Sprintf("    %-*s %s %d", maxLabelW, name, bar, e.count))
 	}

--- a/tui/template_editor.go
+++ b/tui/template_editor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mattn/go-runewidth"
 	"github.com/typemd/typemd/core"
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/bubbles/v2/textinput"
@@ -494,5 +493,5 @@ func (te *templateEditor) SetSize(width, height, propsW int, propsVisible bool) 
 // titleContent returns the title string for the parent to render in the title panel.
 func (te *templateEditor) titleContent(width int) string {
 	title := fmt.Sprintf(" 📝 %s · %s", te.typeName, te.templateName)
-	return runewidth.Truncate(title, width, "…")
+	return truncate(title, width)
 }

--- a/tui/textutil.go
+++ b/tui/textutil.go
@@ -1,0 +1,51 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/mattn/go-runewidth"
+
+	"charm.land/lipgloss/v2"
+)
+
+// softWrapLines wraps each line individually, preserving leading indentation on continuation lines.
+func softWrapLines(content string, width int) string {
+	lines := strings.Split(content, "\n")
+	var result []string
+	for _, line := range lines {
+		if lipgloss.Width(line) <= width {
+			result = append(result, line)
+			continue
+		}
+		// Detect leading whitespace
+		trimmed := strings.TrimLeft(line, " ")
+		indent := line[:len(line)-len(trimmed)]
+		wrapped := lipgloss.NewStyle().Width(width - lipgloss.Width(indent)).Render(trimmed)
+		for _, wl := range strings.Split(wrapped, "\n") {
+			result = append(result, indent+wl)
+		}
+	}
+	return strings.Join(result, "\n")
+}
+
+// truncate shortens a string to fit within maxLen cells, adding ellipsis if needed.
+func truncate(s string, maxLen int) string {
+	return runewidth.Truncate(s, maxLen, "…")
+}
+
+// padRight pads a string with spaces to fill exactly width display cells.
+// Delegates to runewidth.FillRight for CJK/emoji-aware padding.
+func padRight(s string, width int) string {
+	return runewidth.FillRight(s, width)
+}
+
+// padEmoji strips the variation selector (U+FE0F) and pads the emoji
+// to a consistent 2-cell display width for terminal alignment.
+func padEmoji(emoji string) string {
+	display := strings.ReplaceAll(emoji, "\uFE0F", "")
+	ew := runewidth.StringWidth(display)
+	if ew < 2 {
+		return display + strings.Repeat(" ", 2-ew)
+	}
+	return display
+}

--- a/tui/view_mode.go
+++ b/tui/view_mode.go
@@ -504,17 +504,6 @@ func (vm *viewMode) viewColumns() []string {
 	return cols
 }
 
-// truncate shortens a string to fit within maxLen cells, adding ellipsis if needed.
-func truncate(s string, maxLen int) string {
-	return runewidth.Truncate(s, maxLen, "…")
-}
-
-// padRight pads a string with spaces to fill exactly width display cells.
-// Delegates to runewidth.FillRight for CJK/emoji-aware padding.
-func padRight(s string, width int) string {
-	return runewidth.FillRight(s, width)
-}
-
 // displayPropValue formats a property value for table display using the
 // unified DisplayProperty.FormatValue() pipeline.
 func (vm *viewMode) displayPropValue(obj *core.Object, propName string) string {


### PR DESCRIPTION
## Summary

- Extract `softWrapLines`, `truncate`, `padRight`, `padEmoji` into dedicated `tui/textutil.go` for reuse and consistency
- Replace all 6 direct `runewidth.Truncate()` calls across TUI files with shared `truncate()` wrapper
- Remove unused `runewidth` imports from `list.go` and `template_editor.go`

## Issue

Closes #335

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — clean
- [x] Manual: verify TUI renders correctly (text truncation, emoji alignment, soft wrap)