### PR TITLE
refactor(tui): consolidate duplicated lipgloss styles into theme.go

### DIFF
--- a/tui/date_picker.go
+++ b/tui/date_picker.go
@@ -26,9 +26,7 @@ const (
 )
 
 var (
-	dpSegmentFocusStyle = lipgloss.NewStyle().Bold(true).Reverse(true)
-	dpCursorStyle       = lipgloss.NewStyle().Bold(true).Reverse(true)
-	dpTodayStyle        = lipgloss.NewStyle().Bold(true).Underline(true)
+	dpTodayStyle = lipgloss.NewStyle().Bold(true).Underline(true)
 )
 
 const (
@@ -353,11 +351,11 @@ func (dp *datePicker) viewSegment() string {
 
 	switch dp.segment {
 	case segYear:
-		parts[0] = dpSegmentFocusStyle.Render(yearStr)
+		parts[0] = highlightStyle.Render(yearStr)
 	case segMonth:
-		parts[1] = dpSegmentFocusStyle.Render(monthStr)
+		parts[1] = highlightStyle.Render(monthStr)
 	case segDay:
-		parts[2] = dpSegmentFocusStyle.Render(dayStr)
+		parts[2] = highlightStyle.Render(dayStr)
 	}
 
 	return fmt.Sprintf("%s-%s-%s  %s", parts[0], parts[1], parts[2], dow)
@@ -402,7 +400,7 @@ func (dp *datePicker) viewPickerCalendar() string {
 		isToday := dayDate.Equal(today)
 
 		if isCursor {
-			row.WriteString(dpCursorStyle.Render(dayStr))
+			row.WriteString(highlightStyle.Render(dayStr))
 		} else if isToday {
 			row.WriteString(dpTodayStyle.Render(dayStr))
 		} else {

--- a/tui/theme.go
+++ b/tui/theme.go
@@ -35,6 +35,8 @@ var (
 	wikiLinkStyleBase             = lipgloss.NewStyle().Foreground(colorWikiLink)
 	highlightStyle                = lipgloss.NewStyle().Bold(true).Reverse(true)
 	dimStyle                      = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	activeStyle                   = lipgloss.NewStyle().Foreground(lipgloss.Color("0")).Background(lipgloss.Color("6"))
+	boldStyle                     = lipgloss.NewStyle().Bold(true)
 )
 
 // loadTheme reads .typemd/tui.yaml from the vault root and overrides default

--- a/tui/type_editor_prop_detail.go
+++ b/tui/type_editor_prop_detail.go
@@ -7,7 +7,6 @@ import (
 	"github.com/typemd/typemd/core"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
-	"charm.land/lipgloss/v2"
 )
 
 // ── Property Detail Panel ────────────────────────────────────────────────────
@@ -131,8 +130,7 @@ func (te *typeEditor) renderPropPopup(termW, termH int) string {
 		popupW = termW - 10
 	}
 
-	titleStyle := lipgloss.NewStyle().Bold(true)
-	title := titleStyle.Render(fmt.Sprintf("%s (%s)", p.Name, p.Type))
+	title := boldStyle.Render(fmt.Sprintf("%s (%s)", p.Name, p.Type))
 	fullContent := fmt.Sprintf("%s\n──────────────────\n%s", title, b.String())
 
 	return renderPopup(fullContent, termW, termH, popupW)

--- a/tui/view_editor.go
+++ b/tui/view_editor.go
@@ -618,13 +618,10 @@ func (ve *viewEditor) View() string {
 
 	var b strings.Builder
 
-	titleStyle := lipgloss.NewStyle().Bold(true)
-	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("4"))
-	activeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("0")).Background(lipgloss.Color("6"))
 	addStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
 
-	b.WriteString(titleStyle.Render(fmt.Sprintf(" Edit: %s", ve.viewName)) + "\n")
+	b.WriteString(boldStyle.Render(fmt.Sprintf(" Edit: %s", ve.viewName)) + "\n")
 	b.WriteString(dimStyle.Render(" " + strings.Repeat("─", ve.width-4)) + "\n")
 
 	// Layout section (special: single toggle item)

--- a/tui/view_mode.go
+++ b/tui/view_mode.go
@@ -550,12 +550,6 @@ func (vm *viewMode) viewList(rows []viewRow) string {
 	}
 	vm.scroll = widget.AdjustScroll(vm.cursor, vm.scroll, visibleH)
 
-	highlightStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("0")).
-		Background(lipgloss.Color("6"))
-	dimStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("8"))
-
 	emoji := ""
 	if vm.schema != nil && vm.schema.Emoji != "" {
 		emoji = vm.schema.Emoji + " "
@@ -586,7 +580,7 @@ func (vm *viewMode) viewList(rows []viewRow) string {
 			}
 
 			if isCurrent {
-				b.WriteString(highlightStyle.Render(padRight(line, vm.width)) + "\n")
+				b.WriteString(activeStyle.Render(padRight(line, vm.width)) + "\n")
 			} else {
 				b.WriteString(line + "\n")
 			}
@@ -641,8 +635,6 @@ func (vm *viewMode) viewTable(rows []viewRow) string {
 	vm.scroll = widget.AdjustScroll(vm.cursor, vm.scroll, visibleH)
 
 	// Styles
-	dimStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("8"))
 	headerStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("4")).
 		Bold(true)
@@ -650,9 +642,7 @@ func (vm *viewMode) viewTable(rows []viewRow) string {
 		Foreground(lipgloss.Color("4")).
 		Background(lipgloss.Color("236")).
 		Bold(true)
-	activeCellStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("0")).
-		Background(lipgloss.Color("6"))
+	activeCellStyle := activeStyle
 	rowHighlightStyle := lipgloss.NewStyle().
 		Background(lipgloss.Color("235"))
 	dimRowHighlightStyle := lipgloss.NewStyle().
@@ -660,7 +650,7 @@ func (vm *viewMode) viewTable(rows []viewRow) string {
 		Background(lipgloss.Color("235"))
 	editCellStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("0")).
-		Background(lipgloss.Color("214"))
+		Background(colorEditBorder)
 
 	// Build sort indicator map
 	sortIndicators := make(map[string]string)


### PR DESCRIPTION
## Summary

- Add `activeStyle` and `boldStyle` to `theme.go`, replacing 7 duplicated `lipgloss.NewStyle()` calls across 4 files
- Remove redundant `dpSegmentFocusStyle`/`dpCursorStyle` aliases in `date_picker.go`, using `highlightStyle` directly
- Use `colorEditBorder` for `editCellStyle` background instead of duplicating the `"214"` color literal

## Issue

Closes #336

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no warnings
- [x] Manual: launch TUI, verify visual consistency of date picker, view editor, list/table views