### PR TITLE
fix(tui): resolve 5 spec deviations found by e2e audit

### DIFF
--- a/core/vault.go
+++ b/core/vault.go
@@ -31,6 +31,7 @@ type Vault struct {
 	sharedProperties  []Property
 	sharedPropsMap    map[string]Property
 	sharedPropsLoaded bool
+	openReconcile     *ReconcileResult // result of the Open-time reconcile, for consumers that need it after Open
 }
 
 // NewVault creates a Vault rooted at the given directory.
@@ -153,17 +154,28 @@ func (v *Vault) Open() error {
 		return fmt.Errorf("ensure schema: %w", err)
 	}
 
-	events, _, err := v.Reconcile()
+	events, result, err := v.Reconcile()
 	if err != nil {
 		v.closeInternal()
 		return fmt.Errorf("reconcile: %w", err)
 	}
+	v.openReconcile = result
 	if err := v.Project(events); err != nil {
 		v.closeInternal()
 		return fmt.Errorf("project: %w", err)
 	}
 
 	return nil
+}
+
+// TakeOpenReconcileResult returns the ReconcileResult produced during Open()
+// and clears it. Consumers (e.g. the TUI) call this once after Open() to
+// surface unresolved references as warnings without re-running the reconcile.
+// Returns nil on subsequent calls or if Open() was never called.
+func (v *Vault) TakeOpenReconcileResult() *ReconcileResult {
+	r := v.openReconcile
+	v.openReconcile = nil
+	return r
 }
 
 // initAI initializes the AI service based on the configured provider.

--- a/tui/app.go
+++ b/tui/app.go
@@ -140,8 +140,17 @@ func (m model) Init() tea.Cmd {
 	if len(m.keybindingIssues) > 0 {
 		cmds = append(cmds, func() tea.Msg { return keybindingIssuesMsg{} })
 	}
+	// Surface any unresolved references captured during `vault.Open()` as a
+	// toast. See the startupSyncMsg handler in Update for the dispatch path —
+	// doing it via a message ensures the toast model is initialised before
+	// Show() is called.
+	cmds = append(cmds, func() tea.Msg { return startupSyncMsg{} })
 	return tea.Batch(cmds...)
 }
+
+// startupSyncMsg is dispatched once at startup to surface unresolved-reference
+// warnings captured by `vault.Open()` as a toast.
+type startupSyncMsg struct{}
 
 // keybindingIssuesMsg is dispatched once at startup to flush
 // m.keybindingIssues as toast warnings.
@@ -394,6 +403,24 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			items = append(items, widget.ToastItem{Message: iss.Message()})
 		}
 		m.keybindingIssues = nil
+		return m, m.toast.Show(widget.ToastWarning, items)
+
+	case startupSyncMsg:
+		// Surface unresolved references captured by `vault.Open()` — no
+		// second reconcile needed.
+		if m.vault == nil {
+			return m, nil
+		}
+		result := m.vault.TakeOpenReconcileResult()
+		if result == nil {
+			return m, nil
+		}
+		var items []widget.ToastItem
+		items = append(items, unresolvedToToastItems(result.Unresolved)...)
+		items = append(items, unresolvedWikiLinksToToastItems(result.UnresolvedWikiLinks)...)
+		if len(items) == 0 {
+			return m, nil
+		}
 		return m, m.toast.Show(widget.ToastWarning, items)
 
 	case tea.KeyPressMsg:
@@ -659,6 +686,13 @@ func (m *model) refreshData(paths []string) tea.Cmd {
 			m.viewMode.cancelCellEdit()
 		}
 		m.viewMode.reloadObjects()
+		return toastCmd
+	}
+
+	// In stats mode, skip sidebar cursor/selection restore — selectCurrentRow
+	// would otherwise clobber rightPanel back to panelObject/panelTypeEditor
+	// and drop the user out of the stats screen.
+	if m.rightPanel == panelStats && m.statsMode != nil {
 		return toastCmd
 	}
 

--- a/tui/app_render.go
+++ b/tui/app_render.go
@@ -618,6 +618,11 @@ func (m model) View() tea.View {
 		helpKey := m.keys.Help.Help().Key
 		if m.searchResults != nil {
 			helpBar = fmt.Sprintf("  [%s]  Search results  |  esc: clear  |  ↑↓: navigate  |  tab: switch  |  %s: quit", modeLabel, quitKey)
+		} else if m.focus == focusLeft && !m.readOnly {
+			// Sidebar focused in normal mode: include creation hints.
+			newKey := m.keys.NewObject.Help().Key
+			quickKey := m.keys.QuickCreate.Help().Key
+			helpBar = fmt.Sprintf("  [%s]  %s: help  |  %s: new  |  %s: quick create  |  %s: search  |  %s: quit", modeLabel, helpKey, newKey, quickKey, searchKey, quitKey)
 		} else {
 			helpBar = fmt.Sprintf("  [%s]  %s: help  |  %s: search  |  %s: quit", modeLabel, helpKey, searchKey, quitKey)
 		}

--- a/tui/state.go
+++ b/tui/state.go
@@ -27,7 +27,11 @@ type SessionState struct {
 	ViewScroll        int      `yaml:"view_scroll,omitempty"`
 	ViewExpandedGroups []string `yaml:"view_expanded_groups,omitempty"`
 
-	// Stats mode state (present only when TUI was in stats mode on exit)
+	// Stats mode state (present only when TUI was in stats mode on exit).
+	// StatsActive is the canonical marker of "TUI was in stats mode on exit";
+	// the cursor/scroll fields default to 0 and would otherwise be stripped by
+	// `omitempty`, making the presence-of-stats-mode signal ambiguous.
+	StatsActive   bool   `yaml:"stats_active,omitempty"`
 	StatsCursor   int    `yaml:"stats_cursor,omitempty"`
 	StatsScroll   int    `yaml:"stats_scroll,omitempty"`
 	StatsTypeName string `yaml:"stats_type_name,omitempty"`
@@ -97,6 +101,7 @@ func (m model) captureState() SessionState {
 
 	// Capture stats mode state when active
 	if m.rightPanel == panelStats && m.statsMode != nil {
+		state.StatsActive = true
 		state.StatsCursor = m.statsMode.cursor
 		state.StatsScroll = m.statsMode.scroll
 		if m.statsMode.screen == statsDetail {
@@ -180,6 +185,11 @@ func applySessionState(state SessionState, groups []typeGroup) (cursor int, sele
 
 // restoreViewMode attempts to restore view mode from saved session state.
 // Returns a non-nil *viewMode if restoration succeeds, nil otherwise (fallback to sidebar).
+//
+// Fallback chain (tui-session-state spec R10):
+//   - Saved viewName resolves → use it with saved cursor/scroll/expanded groups.
+//   - Saved viewName missing but "default" exists → fall back to default view, reset cursor/scroll.
+//   - Neither saved nor default resolve → return nil (sidebar mode).
 func restoreViewMode(state SessionState, v *core.Vault) *viewMode {
 	if state.ViewTypeName == "" || state.ViewName == "" {
 		return nil
@@ -190,7 +200,17 @@ func restoreViewMode(state SessionState, v *core.Vault) *viewMode {
 		return nil
 	}
 
-	// Reuse newViewMode which handles view loading, querying, and group building
+	// When the saved view is gone, fall back to "default" so the user lands
+	// on a valid view rather than seeing the stale name in the title
+	// (tui-session-state spec R10 S1). The implicit default view is always
+	// available, so no further fallback is needed. Also skip the cursor /
+	// scroll / expanded-groups restore below — they reference the old view
+	// and would be misleading when applied against the default.
+	_, saveErr := v.LoadView(state.ViewTypeName, state.ViewName)
+	if saveErr != nil && state.ViewName != "default" {
+		return newViewMode(state.ViewTypeName, "default", v)
+	}
+
 	vm := newViewMode(state.ViewTypeName, state.ViewName, v)
 
 	// Apply expanded groups from state
@@ -220,7 +240,13 @@ func restoreViewMode(state SessionState, v *core.Vault) *viewMode {
 // Returns a non-nil *statsMode if restoration succeeds, nil otherwise.
 // Stats state takes precedence over view state when both are present.
 func restoreStatsMode(state SessionState, v *core.Vault) *statsMode {
-	hasStatsState := state.StatsTypeName != "" || state.StatsCursor > 0 || state.StatsScroll > 0
+	// Presence of stats_active is the canonical marker. For backwards
+	// compatibility with state files written before stats_active existed,
+	// still restore when any of the other stats_* fields are non-zero.
+	hasStatsState := state.StatsActive ||
+		state.StatsTypeName != "" ||
+		state.StatsCursor > 0 ||
+		state.StatsScroll > 0
 
 	if !hasStatsState {
 		return nil

--- a/tui/state_test.go
+++ b/tui/state_test.go
@@ -972,6 +972,83 @@ func TestRestoreStatsMode_NoStatsState(t *testing.T) {
 	}
 }
 
+// Regression: tui-session-state spec R13/R14 require stats mode to round-trip
+// across quit/relaunch. Without an explicit marker, `omitempty` strips
+// StatsCursor=0 / empty StatsTypeName and both save AND restore break.
+func TestSessionState_StatsActiveFlagRoundTrip(t *testing.T) {
+	state := SessionState{StatsActive: true}
+	data, err := yaml.Marshal(&state)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+	if !strings.Contains(string(data), "stats_active: true") {
+		t.Errorf("expected stats_active: true in YAML, got:\n%s", data)
+	}
+	var decoded SessionState
+	if err := yaml.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+	if !decoded.StatsActive {
+		t.Errorf("StatsActive should round-trip as true, got %v", decoded.StatsActive)
+	}
+}
+
+func TestRestoreStatsMode_StatsActiveOnly(t *testing.T) {
+	// StatsActive=true is enough to trigger restore even when all other
+	// stats_* fields are zero — matches tui-session-state R14 S1.
+	dir := t.TempDir()
+	v := core.NewVault(dir)
+	if err := v.Init(); err != nil {
+		t.Fatalf("vault Init() error = %v", err)
+	}
+	if err := v.Open(); err != nil {
+		t.Fatalf("vault Open() error = %v", err)
+	}
+	defer v.Close()
+
+	state := SessionState{StatsActive: true}
+	sm := restoreStatsMode(state, v)
+	if sm == nil {
+		t.Fatal("restoreStatsMode should return non-nil when StatsActive=true")
+	}
+}
+
+// Regression: tui-session-state spec R10 S1 — when the saved view name is
+// gone but the type still exists, fall back to the default view (not the
+// bogus name).
+func TestRestoreViewMode_DeletedViewFallsBackToDefault(t *testing.T) {
+	dir := t.TempDir()
+	v := core.NewVault(dir)
+	if err := v.Init(); err != nil {
+		t.Fatalf("vault Init() error = %v", err)
+	}
+	if err := v.Open(); err != nil {
+		t.Fatalf("vault Open() error = %v", err)
+	}
+	defer v.Close()
+
+	ts := &core.TypeSchema{Name: "book"}
+	if err := v.SaveType(ts); err != nil {
+		t.Fatalf("SaveType() error = %v", err)
+	}
+
+	state := SessionState{
+		ViewTypeName: "book",
+		ViewName:     "deleted-name-does-not-exist",
+		ViewCursor:   5,
+	}
+	vm := restoreViewMode(state, v)
+	if vm == nil {
+		t.Fatal("restoreViewMode should fall back to default view, not return nil")
+	}
+	if vm.viewName != "default" {
+		t.Errorf("viewName = %q, want %q (should fall back)", vm.viewName, "default")
+	}
+	if vm.cursor != 0 {
+		t.Errorf("cursor = %d, want 0 (should reset when falling back)", vm.cursor)
+	}
+}
+
 func TestRestoreStatsMode_StatsTakesPrecedenceOverView(t *testing.T) {
 	// When both stats and view state are present, stats should take precedence.
 	// restoreStatsMode detects stats state; the caller (Start) checks stats first.


### PR DESCRIPTION
## Summary

- **Toast — sync unresolved references** surface at TUI startup by consuming the ReconcileResult already produced by `vault.Open()` (new `TakeOpenReconcileResult()` accessor), avoiding a second full reconcile on launch.
- **Layout — sidebar help bar** includes `n: new` and `N: quick create` hints when focused in normal mode (tui-layout R15).
- **Session state — deleted view name** falls back to the type's `default` view with cursor/scroll reset, instead of showing the stale name in the title (tui-session-state R10 S1).
- **Session state — stats mode round-trip** via an explicit `stats_active` marker so the presence-of-stats-mode signal isn't lost when cursor/scroll default to 0. Backwards-compatible with state files written before the flag existed.
- **Session state — file-watcher guard** skips sidebar cursor/selection restore when in stats mode (mirrors existing view-mode guard) so external file changes don't drop the user out of the stats screen.

## Issue

Closes #397

3 of the originally filed 8 bugs (keybindings `duration_ms`, `dismiss_key`, and `name_template` pre-fill) did NOT reproduce against current `main` — the original audit was contaminated by tmux session state. Documented in the issue [re-verification comment](https://github.com/typemd/typemd/issues/397#issuecomment-4273637096). Scope narrowed to 5 confirmed bugs.

## Test Plan

- [x] `go test ./tui/... ./tui/widget/... ./core/... ./mcp/...` — all pass (cmd/ has 2 pre-existing unrelated git-state failures, unchanged)
- [x] `go build ./...` — clean build
- [x] Added unit tests: `TestSessionState_StatsActiveFlagRoundTrip`, `TestRestoreStatsMode_StatsActiveOnly`, `TestRestoreViewMode_DeletedViewFallsBackToDefault`
- [x] Manual via tmux PTY: each of the 5 bugs reproduces against the pre-fix binary and passes against the post-fix binary:
  - Bug #3: object body with `[[nonexistent]]` → `⚠` toast appears at startup
  - Bug #4: sidebar help bar shows `n: new | N: quick create`
  - Bug #5: state file `view_name: deleted-view-name` → title reads `page · default`
  - Bug #6: quit from stats mode → `tui-state.yaml` contains `stats_active: true`
  - Bug #7: state file `stats_active: true` → TUI launches into Vault Statistics