### PR TITLE
fix(tui): rebind acts as replace, not add — unbind old default keys

### DIFF
--- a/tui/keybindings.go
+++ b/tui/keybindings.go
@@ -258,6 +258,20 @@ func buildKeyMap(cfg *core.VaultConfig) (keyMap, []KeybindingIssue) {
 		}
 	}
 
+	// A default key that has been rebound away must NOT fall through to its
+	// original `case` in update.go — otherwise rebinds act as an add rather
+	// than a replace (issue #396). Collect every compile-time default key
+	// that is no longer bound to any action and mark it as "unbound" so
+	// translate() returns a sentinel that matches no dispatch case.
+	for _, action := range rebindableActions() {
+		for _, defKey := range defaultKeybindings[action].Keys {
+			if _, stillBound := keyToActions[defKey]; stillBound {
+				continue
+			}
+			keyToPrimary[defKey] = unboundSentinel
+		}
+	}
+
 	dupKeys := make([]string, 0)
 	for k, acts := range keyToActions {
 		if len(acts) > 1 {
@@ -341,12 +355,24 @@ func init() {
 	}
 }
 
+// unboundSentinel is returned by translate() for keys that were compile-time
+// defaults but have been rebound away by the user. It's a deliberate non-match
+// for every `case` in update.go's dispatch switch, so the old default key no
+// longer triggers the action it used to own.
+const unboundSentinel = "\x00unbound\x00"
+
 // translate maps an incoming key string (e.g. msg.String()) to the primary
-// default key string for whichever action currently owns that key. If the key
-// is not bound to any rebindable action, translate returns the input unchanged.
+// default key string for whichever action currently owns that key.
 //
-// This is the dispatch bridge: update.go keeps writing `case "ctrl+s"` (stats)
-// and translate makes a user-configured `ctrl+d` route through that same case.
+// Return rules:
+//   - If the key is still bound to an action, return its primary default
+//     (so update.go's `case "<primary>"` matches).
+//   - If the key is a compile-time default that has been rebound away,
+//     return unboundSentinel (so no case matches — this prevents rebinds
+//     from acting as an add rather than a replace).
+//   - Otherwise return the input unchanged (preserves `tab`, `esc`, arrows,
+//     and character input inside edit modes).
+//
 // O(1) lookup against keyToPrimary, populated once by buildKeyMap.
 func (k keyMap) translate(s string) string {
 	if p, ok := k.keyToPrimary[s]; ok {

--- a/tui/keybindings_test.go
+++ b/tui/keybindings_test.go
@@ -82,10 +82,11 @@ func TestBuildKeyMap_OverrideOneAction(t *testing.T) {
 	if got := km.translate("ctrl+d"); got != "ctrl+s" {
 		t.Errorf("translate(ctrl+d) = %q, want %q (should route to default)", got, "ctrl+s")
 	}
-	// The original default key "ctrl+s" no longer belongs to any action, so
-	// translate returns it unchanged (no action owns it anymore).
-	if got := km.translate("ctrl+s"); got != "ctrl+s" {
-		t.Errorf("translate(ctrl+s) after override = %q, want unchanged %q", got, "ctrl+s")
+	// The original default key "ctrl+s" was rebound away; translate must
+	// return the unbound sentinel so the dispatch switch no longer matches
+	// `case "ctrl+s"` and stats does not open (issue #396).
+	if got := km.translate("ctrl+s"); got != unboundSentinel {
+		t.Errorf("translate(ctrl+s) after override = %q, want unboundSentinel", got)
 	}
 	// And the resolved binding's keys list no longer contains the old default.
 	for _, k := range km.Stats.Keys() {
@@ -268,6 +269,58 @@ func TestKeyMap_TranslateNonActionPassthrough(t *testing.T) {
 		if got := km.translate(s); got != s {
 			t.Errorf("translate(%q) = %q, want unchanged", s, got)
 		}
+	}
+}
+
+// Regression: tui-keybindings spec R1 S1 negative — rebind must act as a
+// replace, not an add. After moving stats to ctrl+d, the old default ctrl+s
+// must not dispatch to the stats case (issue #396).
+func TestKeyMap_TranslateRebindUnbindsOldDefault(t *testing.T) {
+	cfg := &core.VaultConfig{
+		TUI: core.TUIConfig{
+			Keybindings: map[string]string{
+				ActionStats: "ctrl+d",
+			},
+		},
+	}
+	km, issues := buildKeyMap(cfg)
+	if len(issues) != 0 {
+		t.Fatalf("unexpected validation issues: %+v", issues)
+	}
+	if got := km.translate("ctrl+d"); got != "ctrl+s" {
+		t.Errorf("translate(ctrl+d) = %q, want ctrl+s (new key routes to primary)", got)
+	}
+	if got := km.translate("ctrl+s"); got == "ctrl+s" {
+		t.Errorf("translate(ctrl+s) = %q — old default must NOT dispatch to stats case after rebind", got)
+	}
+	if got := km.translate("ctrl+s"); got != unboundSentinel {
+		t.Errorf("translate(ctrl+s) = %q, want unboundSentinel — unbound default should be sentinel", got)
+	}
+}
+
+// Regression: alias keys (e.g. `h` for help, which has primary `?`) should
+// also unbind cleanly when the action is rebound. Every compile-time default
+// key — primary or alias — must be neutralised if it is no longer bound.
+func TestKeyMap_TranslateRebindUnbindsAliasDefaults(t *testing.T) {
+	cfg := &core.VaultConfig{
+		TUI: core.TUIConfig{
+			Keybindings: map[string]string{
+				ActionHelp: "f1",
+			},
+		},
+	}
+	km, issues := buildKeyMap(cfg)
+	if len(issues) != 0 {
+		t.Fatalf("unexpected validation issues: %+v", issues)
+	}
+	// Both `?` (primary) and `h` (alias) must no longer route to help.
+	for _, oldKey := range []string{"?", "h"} {
+		if got := km.translate(oldKey); got != unboundSentinel {
+			t.Errorf("translate(%q) = %q, want unboundSentinel", oldKey, got)
+		}
+	}
+	if got := km.translate("f1"); got != "?" {
+		t.Errorf("translate(f1) = %q, want ? (new key routes to primary)", got)
 	}
 }
 

--- a/websites/docs/src/content/docs/tui/tui.md
+++ b/websites/docs/src/content/docs/tui/tui.md
@@ -448,6 +448,7 @@ tmd config get tui.keybindings.stats
 **Validation behaviour:**
 
 - An unset action — or one with an empty string value — keeps its compile-time default.
+- A rebind is a **replace**, not an add: after `stats: "ctrl+d"`, pressing `ctrl+s` no longer opens stats.
 - Unknown action names show a warning toast at startup and are otherwise ignored.
 - Invalid key strings (typos like `crtl+s`, missing segments like `ctrl+`) show a warning toast and the action falls back to its default.
 - If two actions resolve to the same key, both keep that key and a warning toast lists them — the user resolves the conflict.


### PR DESCRIPTION
## Summary

- After buildKeyMap assembles resolved bindings, walk every compile-time default key and map any that are no longer bound to an action to an `unboundSentinel` in `keyToPrimary`.
- `translate()` now returns the sentinel for rebound-away defaults, so the dispatch switch in `update.go` no longer matches literal `case "ctrl+s"` after `stats: ctrl+d`.
- Covers alias defaults too: rebinding `help` to `f1` neutralises both `?` (primary) and `h` (alias).
- Tightens the pre-existing `TestBuildKeyMap_OverrideOneAction` test that asserted the buggy behaviour.
- Docs: add an explicit "rebind is a replace, not an add" note to the TUI keybindings section.

## Issue

Closes #396

## Test Plan

- [x] `go test ./tui/... ./core/... ./mcp/...` — all pass (new tests `TestKeyMap_TranslateRebindUnbindsOldDefault` and `TestKeyMap_TranslateRebindUnbindsAliasDefaults`)
- [x] `go build ./...` — clean build
- [x] Manual via tmux PTY against `tui.keybindings.stats: "ctrl+d"`:
  - Positive — pressing `ctrl+d` opens stats ✓
  - Negative — pressing `ctrl+s` does **not** open stats ✓ (was FAIL pre-fix)
  - No-override — default `ctrl+s` still opens stats ✓