### PR TITLE
fix(cmd): force C locale when shelling out to git log

### DIFF
--- a/cmd/log.go
+++ b/cmd/log.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -51,6 +52,7 @@ Examples:
 		gitArgs = append(gitArgs, "--", filePath)
 
 		gitCmd := exec.Command("git", gitArgs...)
+		gitCmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C", "LANGUAGE=C")
 		var stdout, stderr bytes.Buffer
 		gitCmd.Stdout = &stdout
 		gitCmd.Stderr = &stderr


### PR DESCRIPTION
## Summary

- `cmd/log.go` matched English substrings in git's stderr (`"not a git repository"`, `"does not have any commits yet"`) to handle two edge cases. Under localized shells (e.g. `LANG=zh_TW.UTF-8`) git emits translated messages, the match fails, and users get a raw localized error instead of the friendly path.
- Two BDD scenarios — `TestBDDFeatures/Vault_not_in_a_git_repository` and `TestBDDFeatures/Object_with_no_commits` — fail on developer machines configured with a non-English locale. The failing scenarios reproduce on a fresh `main` checkout, so this is an environment-sensitive bug rather than a regression.
- Fix: set `LC_ALL=C` (plus `LANG=C`, `LANGUAGE=C`) on the `git log` subprocess so its stderr is stable English, regardless of the parent process locale.

## Issue

Closes #

## Test Plan

- [x] `make build-frontend` (required because `web/frontend.go` uses `//go:embed frontend/dist`)
- [x] `LC_ALL=zh_TW.UTF-8 LANG=zh_TW.UTF-8 go test ./cmd/... -count=1 -run 'TestBDDFeatures/(Vault_not_in_a_git_repository|Object_with_no_commits)'` — now passes (previously failed)
- [x] `LC_ALL=zh_TW.UTF-8 LANG=zh_TW.UTF-8 go test ./cmd/... -count=1 -run TestBDDFeatures` — full cmd BDD suite green under zh_TW
- [x] `go test ./cmd/... -count=1 -run TestBDDFeatures` — full cmd BDD suite green under default locale
- [x] `go vet ./cmd/...` — clean

## Notes for reviewers

- The fix is limited to the single `exec.Command("git", ...)` call in `cmd/log.go`; no behaviour change for English-locale users.
- Considered alternatives: matching exit code patterns or using git porcelain output. Neither is currently available for `git log` in a way that distinguishes the two target cases, so forcing a stable locale is the cleanest change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)